### PR TITLE
Environment: Merge parallel::Environment into gridpack::Environment. fixes #71

### DIFF
--- a/src/applications/development/dynamic_simulation_reduced_y/CMakeLists.txt
+++ b/src/applications/development/dynamic_simulation_reduced_y/CMakeLists.txt
@@ -23,6 +23,7 @@ set(target_libraries
     gridpack_stream
     gridpack_partition
     gridpack_math
+    gridpack_environment
     gridpack_configuration
     gridpack_timer
     gridpack_parallel

--- a/src/applications/development/dynamic_simulation_reduced_y/ds_main.cpp
+++ b/src/applications/development/dynamic_simulation_reduced_y/ds_main.cpp
@@ -17,7 +17,7 @@
 #include <ga.h>
 #include <macdecls.h>
 #include "gridpack/parser/dictionary.hpp"
-#include "gridpack/math/math.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/applications/modules/powerflow/pf_app_module.hpp"
 #include "gridpack/applications/modules/dynamic_simulation/ds_app_module.hpp"
 
@@ -62,8 +62,7 @@ void transferPFtoDS(
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc,argv);
-  gridpack::math::Initialize(&argc,&argv);
+  gridpack::Environment env(argc,argv);
 
   if (1) {
     gridpack::parallel::Communicator world;
@@ -125,8 +124,6 @@ main(int argc, char **argv)
     ds_app.write();
   }
 
-  // Terminate Math libraries
-  gridpack::math::Finalize();
   return 0;
 }
 

--- a/src/applications/development/powerflow2/CMakeLists.txt
+++ b/src/applications/development/powerflow2/CMakeLists.txt
@@ -19,6 +19,7 @@ set(target_libraries
     gridpack_components
     gridpack_stream
     gridpack_partition
+    gridpack_environment
     gridpack_math
     gridpack_configuration
     gridpack_timer

--- a/src/applications/development/powerflow2/pf_app2.cpp
+++ b/src/applications/development/powerflow2/pf_app2.cpp
@@ -352,12 +352,10 @@ PFApp2::execute(int argc, char** argv)
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
-  gridpack::math::Initialize(&argc,&argv);
+  gridpack::Environment env(argc, argv);
 
   gridpack::powerflow::PFApp2 app;
   app.execute(argc, argv);
 
-  gridpack::math::Finalize();
 }
 

--- a/src/applications/examples/hello_world/CMakeLists.txt
+++ b/src/applications/examples/hello_world/CMakeLists.txt
@@ -17,6 +17,7 @@ set(target_libraries
     gridpack_components
     gridpack_stream
     gridpack_partition
+    gridpack_environment
     gridpack_math
     gridpack_configuration
     gridpack_timer

--- a/src/applications/examples/hello_world/hw_main.cpp
+++ b/src/applications/examples/hello_world/hw_main.cpp
@@ -21,27 +21,10 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
-#if 0
-  // Initialize MPI libraries
-  int ierr = MPI_Init(&argc, &argv);
-
-  GA_Initialize();
-  int stack = 200000, heap = 200000;
-  MA_init(C_DBL, stack, heap);
-#endif
+  gridpack::Environment env(argc, argv);
 
   gridpack::hello_world::HWApp app;
   app.execute(argc, argv);
 
-#if 0
-  GA_Terminate();
-
-  // Terminate Math libraries
-  gridpack::math::Finalize();
-  // Clean up MPI libraries
-  ierr = MPI_Finalize();
-  return ierr;
-#endif
   return 0;
 }

--- a/src/applications/examples/powerflow/CMakeLists.txt
+++ b/src/applications/examples/powerflow/CMakeLists.txt
@@ -20,6 +20,7 @@ set(target_libraries
     gridpack_stream
     gridpack_partition
     gridpack_math
+    gridpack_environment
     gridpack_configuration
     gridpack_timer
     gridpack_parallel

--- a/src/applications/examples/powerflow/pf_main.cpp
+++ b/src/applications/examples/powerflow/pf_main.cpp
@@ -26,7 +26,7 @@ main(int argc, char **argv)
 {
   // Initialize parallel environment. This will start up
   // the underlying communication libraries
-  gridpack::parallel::Environment env(argc,argv);
+  gridpack::Environment env(argc,argv);
 
   // Initialize Math libraries
   gridpack::math::Initialize(&argc,&argv);

--- a/src/applications/examples/resistor_grid/CMakeLists.txt
+++ b/src/applications/examples/resistor_grid/CMakeLists.txt
@@ -18,6 +18,7 @@ set(target_libraries
     gridpack_stream
     gridpack_partition
     gridpack_parallel
+    gridpack_environment
     gridpack_math
     gridpack_configuration
     gridpack_timer

--- a/src/applications/examples/resistor_grid/rg_main.cpp
+++ b/src/applications/examples/resistor_grid/rg_main.cpp
@@ -21,29 +21,10 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
-#if 0
-  // Initialize MPI libraries
-  int ierr = MPI_Init(&argc, &argv);
-
-  GA_Initialize();
-  int stack = 200000, heap = 200000;
-  MA_init(C_DBL, stack, heap);
-#endif
-
-  // Initialize Math libraries
-  gridpack::math::Initialize(&argc,&argv);
+  gridpack::Environment env(argc, argv);
 
   gridpack::resistor_grid::RGApp app;
   app.execute(argc, argv);
 
-  // Terminate Math libraries
-  gridpack::math::Finalize();
-#if 0
-  GA_Terminate();
-
-  // Clean up MPI libraries
-  ierr = MPI_Finalize();
-#endif
   return 0;
 }

--- a/src/applications/modules/dynamic_simulation/CMakeLists.txt
+++ b/src/applications/modules/dynamic_simulation/CMakeLists.txt
@@ -20,6 +20,7 @@ set(target_libraries
     gridpack_stream
     gridpack_partition
     gridpack_parallel
+    gridpack_environment
     gridpack_math
     gridpack_configuration
     gridpack_timer

--- a/src/applications/modules/dynamic_simulation/test/ds_test.cpp
+++ b/src/applications/modules/dynamic_simulation/test/ds_test.cpp
@@ -61,8 +61,7 @@ void transferPFtoDS(
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc,argv);
-  gridpack::math::Initialize(&argc,&argv);
+  gridpack::Environment env(argc,argv);
 
   if (1) {
     gridpack::parallel::Communicator world;
@@ -124,8 +123,6 @@ main(int argc, char **argv)
     ds_app.write();
   }
 
-  // Terminate Math libraries
-  gridpack::math::Finalize();
   return 0;
 }
 

--- a/src/applications/modules/powerflow/CMakeLists.txt
+++ b/src/applications/modules/powerflow/CMakeLists.txt
@@ -18,6 +18,7 @@ set(target_libraries
     gridpack_partition
     gridpack_parallel
     gridpack_stream
+    gridpack_environment
     gridpack_math
     gridpack_configuration
     gridpack_timer

--- a/src/applications/modules/powerflow/test/pf_test.cpp
+++ b/src/applications/modules/powerflow/test/pf_test.cpp
@@ -24,8 +24,7 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc,argv);
-  gridpack::math::Initialize(&argc,&argv);
+  gridpack::Environment env(argc,argv);
 
   if (1) {
     gridpack::parallel::Communicator world;
@@ -62,8 +61,6 @@ main(int argc, char **argv)
     pf_app.saveData();
   }
 
-  // Terminate Math libraries
-  gridpack::math::Finalize();
   return 0;
 }
 

--- a/src/applications/powerflow/pf_main.cpp
+++ b/src/applications/powerflow/pf_main.cpp
@@ -1,3 +1,4 @@
+
 /*
  *     Copyright (c) 2013 Battelle Memorial Institute
  *     Licensed under modified BSD License. A copy of this license can be found
@@ -24,7 +25,7 @@ const char* help = "GridPACK power flow application";
 int main(int argc, char **argv)
 {
   // Initialize libraries (parallel and math)
-  gridpack::Environment env(argc,argv,help,"input_14.xml");
+  gridpack::Environment env(argc,argv,help);
 
   if (1) {
     gridpack::utility::CoarseTimer *timer =

--- a/src/component/CMakeLists.txt
+++ b/src/component/CMakeLists.txt
@@ -15,6 +15,8 @@
 
 set(target_libraries
     gridpack_parallel
+    gridpack_math
+    gridpack_environment
     ${GA_LIBRARIES}
     ${Boost_LIBRARIES}
     ${MPI_CXX_LIBRARIES})

--- a/src/component/test/component_serialization.cpp
+++ b/src/component/test/component_serialization.cpp
@@ -1,3 +1,4 @@
+
 /*
  *     Copyright (c) 2013 Battelle Memorial Institute
  *     Licensed under modified BSD License. A copy of this license can be found
@@ -36,6 +37,7 @@ typedef boost::archive::binary_oarchive outarchive;
 
 #include "gridpack/utilities/exception.hpp"
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "data_collection.hpp"
 #include "base_component.hpp"
 
@@ -439,7 +441,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   int result = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   return result;
 }

--- a/src/configuration/CMakeLists.txt
+++ b/src/configuration/CMakeLists.txt
@@ -22,6 +22,8 @@ gridpack_set_library_version(gridpack_configuration)
 add_dependencies(gridpack_configuration external_build)
 
 set(target_libraries 
+  gridpack_math
+  gridpack_environment
   gridpack_parallel
   ${GA_LIBRARIES}
   ${Boost_LIBRARIES} 
@@ -31,6 +33,7 @@ set(target_libraries
 if (GRIDPACK_LIB_LINK_LIBRARIES)
   target_link_libraries(gridpack_configuration
     gridpack_parallel
+    gridpack_environment
     )
 endif()
 

--- a/src/configuration/test/configuration_test.cpp
+++ b/src/configuration/test/configuration_test.cpp
@@ -23,6 +23,7 @@
 #include <boost/serialization/string.hpp>
 
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/utilities/uncopyable.hpp"
 #include "configurable.hpp"
 
@@ -111,7 +112,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
 
   gridpack::utility::Configuration *config =

--- a/src/environment/CMakeLists.txt
+++ b/src/environment/CMakeLists.txt
@@ -10,21 +10,14 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
-# Last Change: 2018-09-20 11:17:39 d3g096
+# Last Change: 2020-01-07 08:51:33 d3g096
 # -------------------------------------------------------------
 
 add_library(gridpack_environment 
   environment.cpp
 )
 
-# For some reason this is necessary for Mac OS X, but messes things up on Linux
-if (GRIDPACK_LIB_LINK_LIBRARIES)
-  target_link_libraries(gridpack_environment gridpack_math
-    ${Boost_LIBRARIES} 
-    ${GA_LIBRARIES} 
-    ${MPI_CXX_LIBRARIES}
-    )
-endif()
+target_link_libraries(gridpack_environment gridpack_math)
   
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (GA_FOUND)

--- a/src/environment/environment.cpp
+++ b/src/environment/environment.cpp
@@ -24,17 +24,13 @@
 
 namespace gridpack {
 
-void Environment::PrintHelp(char** argv,const char* help,const char* config_filein)
+void Environment::PrintHelp(char** argv,const char* help)
 
 {
   // Check if help (-h or -help) is given at command line
   if(clparser.cmdOptionExists("-h") || clparser.cmdOptionExists("-help")) {
     printf("Application Name:\n\t %s\n",argv[0]);
     if(help) printf("Description:\n\t %s\n",help);
-    if(config_filein) {
-      std::strcpy(config_file,config_filein);
-      printf("Configuration file:\n\t%s\n",config_file);
-    }
     exit(1);
   }
 }
@@ -52,9 +48,9 @@ Environment::Environment(int argc, char **argv):p_boostEnv(argc,argv),clparser(a
   gridpack::math::Initialize(&argc,&argv);
 }
 
-Environment::Environment(int argc, char **argv,const char* help,const char* config_filein): p_boostEnv(argc,argv),clparser(argc,argv)
+Environment::Environment(int argc, char **argv,const char* help): p_boostEnv(argc,argv),clparser(argc,argv)
 {
-  PrintHelp(argv,help,config_file);
+  PrintHelp(argv,help);
   pma_stack = 200000;
   pma_heap  = 200000;
 
@@ -62,17 +58,16 @@ Environment::Environment(int argc, char **argv,const char* help,const char* conf
   MA_init(C_DBL,pma_stack,pma_heap);
   gridpack::math::Initialize(&argc,&argv);
 }
-
-  Environment::Environment(int argc, char **argv,const char* help,const char* config_filein,const long int& ma_stack,const long int& ma_heap): p_boostEnv(argc,argv),clparser(argc,argv)
+  
+Environment::Environment(int argc, char **argv,const char* help,const long int& ma_stack,const long int& ma_heap): p_boostEnv(argc,argv),clparser(argc,argv)
 {
-  PrintHelp(argv,help,config_file);
+  PrintHelp(argv,help);
 
   GA_Initialize();
   MA_init(C_DBL,ma_stack,ma_heap);
   gridpack::math::Initialize(&argc,&argv);
 
 }
-
 
 Environment::~Environment(void)
 {

--- a/src/environment/environment.cpp
+++ b/src/environment/environment.cpp
@@ -18,20 +18,14 @@
 // -------------------------------------------------------------
 
 #include <stdio.h>
+#include <ga++.h>
 #include "environment.hpp"
-#include "gridpack/parallel/environment.hpp"
 #include "gridpack/math/math.hpp"
 
 namespace gridpack {
 
-// -------------------------------------------------------------
-//  class Environment
-// -------------------------------------------------------------
+void Environment::PrintHelp(char** argv,const char* help,const char* config_filein)
 
-// -------------------------------------------------------------
-// Environment:: constructors / destructor
-// -------------------------------------------------------------
-  Environment::Environment(int& argc, char **argv,const char* help,const char* config_filein) : parenv(argc,argv),clparser(argc,argv)
 {
   // Check if help (-h or -help) is given at command line
   if(clparser.cmdOptionExists("-h") || clparser.cmdOptionExists("-help")) {
@@ -43,16 +37,49 @@ namespace gridpack {
     }
     exit(1);
   }
+}
+// -------------------------------------------------------------
+//  class Environment
+// -------------------------------------------------------------
+
+Environment::Environment(int argc, char **argv):p_boostEnv(argc,argv),clparser(argc,argv)
+{
+  pma_stack = 200000;
+  pma_heap  = 200000;
+
+  GA_Initialize();
+  MA_init(C_DBL,pma_stack,pma_heap);
   gridpack::math::Initialize(&argc,&argv);
 }
 
+Environment::Environment(int argc, char **argv,const char* help,const char* config_filein): p_boostEnv(argc,argv),clparser(argc,argv)
+{
+  PrintHelp(argv,help,config_file);
+  pma_stack = 200000;
+  pma_heap  = 200000;
+
+  GA_Initialize();
+  MA_init(C_DBL,pma_stack,pma_heap);
+  gridpack::math::Initialize(&argc,&argv);
+}
+
+  Environment::Environment(int argc, char **argv,const char* help,const char* config_filein,const long int& ma_stack,const long int& ma_heap): p_boostEnv(argc,argv),clparser(argc,argv)
+{
+  PrintHelp(argv,help,config_file);
+
+  GA_Initialize();
+  MA_init(C_DBL,ma_stack,ma_heap);
+  gridpack::math::Initialize(&argc,&argv);
+
+}
+
+
 Environment::~Environment(void)
 {
-  int ierr;
   // Finalize math libraries
   gridpack::math::Finalize();
 
-  // GA and MPI will be finalized by Environment class
+  GA_Terminate();
 }
 
 } // namespace gridpack

--- a/src/environment/environment.hpp
+++ b/src/environment/environment.hpp
@@ -67,17 +67,14 @@ public:
    * @param argc        number of program command line arguments
    * @param argv        command line arguments
    * @param help        help string to be displayed for the application
-   * @param config_file name of the config file
    * 
    * @return 
    */
   Environment(int argc, char **argv,
-              const char* help,
-	      const char* config_file);
+              const char* help);
 
   Environment(int argc, char **argv,
               const char* help,
-	      const char* config_file,
 	      const long int& ma_stack,
               const long int& ma_heap);
 
@@ -98,10 +95,7 @@ private:
   long int pma_stack;
   long int pma_heap;
 
-  // Configuration file
-  char config_file[100];
-
-  void PrintHelp(char **argv,const char* help,const char* config_file);
+  void PrintHelp(char **argv,const char* help);
 };
 
 } // namespace gridpack

--- a/src/environment/environment.hpp
+++ b/src/environment/environment.hpp
@@ -21,7 +21,9 @@
 #ifndef _app_environment_hpp_
 #define _app_environment_hpp_
 
-#include "gridpack/parallel/environment.hpp"
+#include <boost/mpi.hpp>
+#include "gridpack/utilities/uncopyable.hpp"
+
 
 namespace gridpack {
 
@@ -54,7 +56,7 @@ private:
 // -------------------------------------------------------------
 //  class Environment
 // -------------------------------------------------------------
-  class Environment
+  class Environment : private utility::Uncopyable
 {
 public:
 
@@ -69,21 +71,37 @@ public:
    * 
    * @return 
    */
-  Environment(int& argc, char **argv,
+  Environment(int argc, char **argv,
               const char* help,
 	      const char* config_file);
 
+  Environment(int argc, char **argv,
+              const char* help,
+	      const char* config_file,
+	      const long int& ma_stack,
+              const long int& ma_heap);
+
+  Environment(int argc, char **argv);
+
+
   /// Destructor
   ~Environment(void);
+
+protected:
+  boost::mpi::environment p_boostEnv;
+
 private:
   // Command line parser
   CommandLineParser clparser;
 
-  // environment for initializing the parallel libraries
-  gridpack::parallel::Environment parenv;
+  // Stack and heap for GA
+  long int pma_stack;
+  long int pma_heap;
 
   // Configuration file
   char config_file[100];
+
+  void PrintHelp(char **argv,const char* help,const char* config_file);
 };
 
 } // namespace gridpack

--- a/src/expression/CMakeLists.txt
+++ b/src/expression/CMakeLists.txt
@@ -13,6 +13,8 @@
 # Last Change:
 # -------------------------------------------------------------
 set(target_libraries
+  gridpack_math
+  gridpack_environment
   gridpack_parallel
 )
 

--- a/src/expression/test/expression_test.cpp
+++ b/src/expression/test/expression_test.cpp
@@ -37,6 +37,7 @@
 
 #include "gridpack/utilities/exception.hpp"
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 
 #include "gridpack/expression/variable.hpp"
 #include "gridpack/expression/functions.hpp"
@@ -231,7 +232,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   int lresult = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   lresult = (lresult == boost::exit_success ? 0 : 1);

--- a/src/expression/test/variable_test.cpp
+++ b/src/expression/test/variable_test.cpp
@@ -35,6 +35,7 @@
 
 #include "gridpack/utilities/exception.hpp"
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 
 #include "variable.hpp"
 
@@ -213,7 +214,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   int lresult = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   lresult = (lresult == boost::exit_success ? 0 : 1);

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -12,6 +12,7 @@
 set(gridpack_math_sources)
 set(target_libraries 
   gridpack_configuration 
+  gridpack_environment
   gridpack_parallel 
   gridpack_timer
   ${GA_LIBRARIES}

--- a/src/math/matrix_inverse.cpp
+++ b/src/math/matrix_inverse.cpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <gridpack/parallel/parallel.hpp>
+#include <gridpack/environment/environment.hpp>
 #include <gridpack/timer/coarse_timer.hpp>
 #include <gridpack/utilities/exception.hpp>
 #include <gridpack/math/math.hpp>
@@ -35,9 +36,8 @@ using namespace gridpack;
 int
 main(int argc, char **argv)
 {
-  parallel::Environment env(argc, argv);
+  Environment env(argc, argv);
   parallel::Communicator world;
-  math::Initialize(&argc,&argv);
 
   std::string cinput("input.xml");
   if (argc > 1) {
@@ -96,7 +96,6 @@ main(int argc, char **argv)
     return 2;
   }
   
-  math::Finalize();
   timer->dump();
   return 0;
 }

--- a/src/math/small_matrix_solve.cpp
+++ b/src/math/small_matrix_solve.cpp
@@ -23,6 +23,7 @@
 #include <boost/assert.hpp>
 
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/utilities/exception.hpp"
 #include "math.hpp"
 #include "linear_matrix_solver.hpp"
@@ -33,11 +34,9 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   gridpack::parallel::Communicator self = world.split(world.rank());
-
-  gridpack::math::Initialize(&argc,&argv);
 
   boost::scoped_ptr<gridpack::utility::Configuration> 
     config(gridpack::utility::Configuration::configuration());
@@ -143,7 +142,5 @@ main(int argc, char **argv)
   Xorig.reset();
   X.reset();
 
-  gridpack::math::Finalize();
-  
   return 0;
 }

--- a/src/math/test/test_main.cpp
+++ b/src/math/test/test_main.cpp
@@ -23,6 +23,7 @@
 
 #include "gridpack/utilities/exception.hpp"
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/configuration/configuration.hpp"
 #include "math.hpp"
 
@@ -54,9 +55,8 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
-  gridpack::math::Initialize(&argc,&argv);
 
   // In the GridPACK setup, CTest determines unit test success or
   // failure by a phrase produced by Boost::test. When run in
@@ -67,7 +67,6 @@ main(int argc, char **argv)
   int lresult = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   lresult = (lresult == boost::exit_success ? 0 : 1);
   int gresult;
-  gridpack::math::Finalize();
 
   boost::mpi::all_reduce(world, lresult, gresult, std::plus<int>());
   if (world.rank() == 0) {

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -15,6 +15,8 @@
 
 set(target_libraries 
   gridpack_timer
+  gridpack_math
+  gridpack_environment
   ${GA_LIBRARIES} 
   ${Boost_LIBRARIES} 
   ${MPI_CXX_LIBRARIES}

--- a/src/network/base_network.hpp
+++ b/src/network/base_network.hpp
@@ -37,6 +37,7 @@
 #include "gridpack/parallel/ga_shuffler.hpp"
 #include "gridpack/timer/coarse_timer.hpp"
 #include "gridpack/utilities/exception.hpp"
+#include "gridpack/environment/environment.hpp"
 
 namespace gridpack {
 namespace network {

--- a/src/network/test/network_partition.cpp
+++ b/src/network/test/network_partition.cpp
@@ -25,6 +25,7 @@
 
 #include "gridpack/component/base_component.hpp"
 #include "base_network.hpp"
+#include "gridpack/environment/environment.hpp"
 
 // -------------------------------------------------------------
 //  class BogusBus
@@ -443,7 +444,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   int result = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   return result;
 }

--- a/src/network/test/test_network.cpp
+++ b/src/network/test/test_network.cpp
@@ -748,7 +748,7 @@ bool init_function(void)
 
 int main (int argc, char **argv) {
 
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
 
   int me = world.rank();

--- a/src/optimization/CMakeLists.txt
+++ b/src/optimization/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 set(target_libraries
   gridpack_components
   gridpack_partition
+  gridpack_environment
   gridpack_math
   gridpack_timer
   gridpack_expression

--- a/src/optimization/test/optimizer_test.cpp
+++ b/src/optimization/test/optimizer_test.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <vector>
 
+#include "gridpack/environment/environment.hpp"
 #include "optimizer.hpp"
 
 #define BOOST_TEST_NO_MAIN
@@ -399,7 +400,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
 
   boost::scoped_ptr<gridpack::utility::Configuration> 

--- a/src/parallel/CMakeLists.txt
+++ b/src/parallel/CMakeLists.txt
@@ -13,8 +13,17 @@
 # Last Change: 2019-08-16 13:41:44 d3g096
 # -------------------------------------------------------------
 
+set(target_libraries
+   gridpack_parallel
+   gridpack_math
+   gridpack_timer
+   gridpack_environment
+   ${Boost_LIBRARIES} 
+   ${GA_LIBRARIES} 
+   ${MPI_CXX_LIBRARIES}
+)
+	
 add_library(gridpack_parallel 
-  environment.cpp
   communicator.cpp
   distributed.cpp
   index_hash.cpp
@@ -25,11 +34,7 @@ gridpack_set_library_version(gridpack_parallel)
 
 # For some reason this is necessary for Mac OS X, but messes things up on Linux
 if (GRIDPACK_LIB_LINK_LIBRARIES)
-  target_link_libraries(gridpack_parallel
-    ${Boost_LIBRARIES} 
-    ${GA_LIBRARIES} 
-    ${MPI_CXX_LIBRARIES}
-    )
+  target_link_libraries(${target_libraries})
 endif()
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -41,7 +46,6 @@ endif()
 # gridpack header installation
 # -------------------------------------------------------------
 install(FILES
-  environment.hpp
   communicator.hpp
   parallel.hpp
   distributed.hpp
@@ -70,11 +74,10 @@ install(TARGETS
 # A simple MPI program (that does not use boost::test)
 # -------------------------------------------------------------
 add_executable(greetings test/greetings.cpp)
-target_link_libraries(greetings gridpack_parallel 
-  ${GA_LIBRARIES} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES})
+target_link_libraries(greetings ${target_libraries})
 
 if (NOT USE_PROGRESS_RANKS)
-  add_test(greetings_serial greetings)
+  add_test(greetings_serial greetings)	
   set_tests_properties(greetings_serial
     PROPERTIES 
     PASS_REGULAR_EXPRESSION "I am process 0 of [1-9].*$"
@@ -95,8 +98,7 @@ set_tests_ldpath(greetings_parallel)
 # A simple program to test the task manager
 # -------------------------------------------------------------
 add_executable(task_test test/task_test.cpp ../timer/local_timer.cpp)
-target_link_libraries(task_test gridpack_parallel 
-  ${GA_LIBRARIES} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES})
+target_link_libraries(task_test ${target_libraries})
 
 gridpack_add_run_test(task_test task_test "")
 
@@ -113,11 +115,7 @@ gridpack_add_unit_test(mpi_test mpi_test)
 # TEST: shuffle_test
 # -------------------------------------------------------------
 add_executable(shuffle_test test/shuffle_test.cpp)
-target_link_libraries(shuffle_test 
-  gridpack_parallel 
-  ${GA_LIBRARIES} 
-  ${Boost_LIBRARIES} 
-  ${MPI_CXX_LIBRARIES}
+target_link_libraries(shuffle_test ${target_libraries}
 )
 gridpack_add_unit_test(shuffle shuffle_test)
 
@@ -126,8 +124,7 @@ gridpack_add_unit_test(shuffle shuffle_test)
 # A simple program to test the task manager
 # -------------------------------------------------------------
 add_executable(hash_test test/hash_test.cpp)
-target_link_libraries(hash_test gridpack_parallel 
-  ${GA_LIBRARIES} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES} gridpack_timer)
+target_link_libraries(hash_test ${target_libraries})
 
 gridpack_add_unit_test(hash_test hash_test)
 
@@ -136,8 +133,7 @@ gridpack_add_unit_test(hash_test hash_test)
 # A simple program to test the random number generator
 # -------------------------------------------------------------
 add_executable(random_test test/random_test.cpp)
-target_link_libraries(random_test gridpack_parallel 
-  ${GA_LIBRARIES} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES})
+target_link_libraries(random_test ${target_libraries})
 
 gridpack_add_run_test(random_test random_test "")
 
@@ -146,8 +142,7 @@ gridpack_add_run_test(random_test random_test "")
 # A simple program to test the global store module
 # -------------------------------------------------------------
 add_executable(store_test test/store_test.cpp)
-target_link_libraries(store_test gridpack_parallel 
-  ${GA_LIBRARIES} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES})
+target_link_libraries(store_test ${target_libraries})
 
 gridpack_add_run_test(store_test store_test "")
 
@@ -156,7 +151,6 @@ gridpack_add_run_test(store_test store_test "")
 # A simple program to test the global vector module
 # -------------------------------------------------------------
 add_executable(vector_test test/vector_test.cpp)
-target_link_libraries(vector_test gridpack_parallel 
-  ${GA_LIBRARIES} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES})
+target_link_libraries(vector_test ${target_libraries})
 
 gridpack_add_run_test(vector_test vector_test "")

--- a/src/parallel/test/greetings.cpp
+++ b/src/parallel/test/greetings.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <ga.h>
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 
 // -------------------------------------------------------------
 //  Main Program
@@ -34,7 +35,7 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
 
   // Limit scope so that program exits cleanly
   if (1) {

--- a/src/parallel/test/hash_test.cpp
+++ b/src/parallel/test/hash_test.cpp
@@ -17,6 +17,7 @@
 #include "gridpack/network/base_network.hpp"
 #include "gridpack/parallel/index_hash.hpp"
 #include "gridpack/timer/coarse_timer.hpp"
+#include "gridpack/environment/environment.hpp"
 
 #define XDIM 100
 #define YDIM 100
@@ -288,7 +289,7 @@ bool init_function(void)
 
 int main (int argc, char **argv) {
 
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
 
   int me = world.rank();

--- a/src/parallel/test/random_test.cpp
+++ b/src/parallel/test/random_test.cpp
@@ -24,6 +24,7 @@
 #include <ga.h>
 #include "gridpack/parallel/parallel.hpp"
 #include "gridpack/parallel/random.hpp"
+#include "gridpack/environment/environment.hpp"
 
 #define MAX_VALS  1000000
 
@@ -35,7 +36,7 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   GA_Initialize();
   // Create an artificial scope so that all objects call their destructors
   // before GA_Terminate is called

--- a/src/parallel/test/shuffle_test.cpp
+++ b/src/parallel/test/shuffle_test.cpp
@@ -28,6 +28,8 @@
 #include "shuffler.hpp"
 #include "ga_shuffler.hpp"
 
+#include "gridpack/environment/environment.hpp"
+
 // -------------------------------------------------------------
 // struct Tester
 // -------------------------------------------------------------
@@ -255,7 +257,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   return ::boost::unit_test::unit_test_main( &init_function, argc, argv );
 }
 

--- a/src/parallel/test/store_test.cpp
+++ b/src/parallel/test/store_test.cpp
@@ -24,6 +24,7 @@
 #include <ga.h>
 #include "gridpack/parallel/parallel.hpp"
 #include "gridpack/parallel/global_store.hpp"
+#include "gridpack/environment/environment.hpp"
 
 #define MAX_VEC  1000
 
@@ -40,7 +41,7 @@ typedef struct {int ival;
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   // Create an artificial scope so that all objects call their destructors
   // before GA_Terminate is called
   if (1) {

--- a/src/parallel/test/task_test.cpp
+++ b/src/parallel/test/task_test.cpp
@@ -29,6 +29,7 @@
 #include "gridpack/parallel/parallel.hpp"
 #include "gridpack/parallel/task_manager.hpp"
 #include "gridpack/timer/local_timer.hpp"
+#include "gridpack/environment/environment.hpp"
 
 // -------------------------------------------------------------
 //  Main Program
@@ -36,7 +37,7 @@
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   GA_Initialize();
   // Create an artificial scope so that all objects call their destructors
   // before GA_Terminate is called

--- a/src/parallel/test/vector_test.cpp
+++ b/src/parallel/test/vector_test.cpp
@@ -24,6 +24,7 @@
 #include <ga.h>
 #include "gridpack/parallel/parallel.hpp"
 #include "gridpack/parallel/global_vector.hpp"
+#include "gridpack/environment/environment.hpp"
 
 
 #define VEC_LEN  1000
@@ -39,7 +40,7 @@ typedef struct {int ival;
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   // Create an artificial scope so that all objects call their destructors
   // before GA_Terminate is called
   if (1) {

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -27,6 +27,8 @@ if (PARMETIS_FOUND)
 endif()
 
 set(target_libraries
+    gridpack_math
+    gridpack_environment
     gridpack_partition
     gridpack_components
     gridpack_parallel

--- a/src/parser/test/PTI23_test.cpp
+++ b/src/parser/test/PTI23_test.cpp
@@ -21,6 +21,7 @@
 #include <gridpack/parser/PTI23_parser.hpp>
 #include <gridpack/configuration/configuration.hpp>
 #include <gridpack/timer/coarse_timer.hpp>
+#include <gridpack/environment/environment.hpp>
 
 #include "mpi.h"
 #include <macdecls.h>
@@ -86,7 +87,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   int me = world.rank();
   if (me == 0) {

--- a/src/parser/test/bus_table_test.cpp
+++ b/src/parser/test/bus_table_test.cpp
@@ -11,7 +11,7 @@
 
 #include "mpi.h"
 #include <macdecls.h>
-#include "gridpack/parallel/environment.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/network/base_network.hpp"
 #include "gridpack/parser/bus_table.hpp"
 #include "gridpack/timer/coarse_timer.hpp"
@@ -99,7 +99,7 @@ void factor_grid(int nproc, int xsize, int ysize, int *pdx, int *pdy)
 int main(int argc, char **argv)
 {
 
-  gridpack::parallel::Environment env(argc,argv);
+  gridpack::Environment env(argc,argv);
   gridpack::parallel::Communicator comm;
   MPI_Comm mpi_world = static_cast<MPI_Comm>(comm);
   int ierr;

--- a/src/parser/test/hash_distr_test.cpp
+++ b/src/parser/test/hash_distr_test.cpp
@@ -17,6 +17,7 @@
 #include "gridpack/network/base_network.hpp"
 #include "gridpack/parser/hash_distr.hpp"
 #include "gridpack/timer/coarse_timer.hpp"
+#include "gridpack/environment/environment.hpp"
 
 #define XDIM 10
 #define YDIM 10
@@ -716,7 +717,7 @@ bool init_function(void)
 
 int main (int argc, char **argv) {
 
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
 
   int me = world.rank();

--- a/src/parser/test/parser_test.cpp
+++ b/src/parser/test/parser_test.cpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <ga.h>
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/parallel/communicator.hpp"
 #include "gridpack/component/base_component.hpp"
 #include "gridpack/network/base_network.hpp"
@@ -62,7 +63,7 @@ struct branch_data {int idx1; int idx2;};
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   GA_Initialize();
   // Create an artificial scope so that all objects call their destructors
   // before GA_Terminate is called

--- a/src/partition/CMakeLists.txt
+++ b/src/partition/CMakeLists.txt
@@ -16,6 +16,8 @@
 set(gridpack_partition_sources)
 
 set(target_libraries 
+  gridpack_math
+  gridpack_environment
   gridpack_timer
   gridpack_parallel 
   ${GA_LIBRARIES} 

--- a/src/partition/test/parmetis_test.cpp
+++ b/src/partition/test/parmetis_test.cpp
@@ -25,6 +25,7 @@
 #include "simple_adjacency.hpp"
 #include "parmetis/parmetis_graph_wrapper.hpp"
 #include "gridpack/parallel/printit.hpp"
+#include "gridpack/environment/environment.hpp"
 
 
 BOOST_AUTO_TEST_SUITE( ParMETISTest )
@@ -75,7 +76,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   int result = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   return result;
 }

--- a/src/partition/test/partition_test.cpp
+++ b/src/partition/test/partition_test.cpp
@@ -23,6 +23,7 @@
 #include <boost/serialization/vector.hpp>
 #include "gridpack/utilities/exception.hpp"
 #include "gridpack/parallel/parallel.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "simple_adjacency.hpp"
 #include "graph_partitioner.hpp"
 
@@ -249,7 +250,7 @@ bool init_function()
 int
 main(int argc, char **argv)
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   int result = ::boost::unit_test::unit_test_main( &init_function, argc, argv );
   return result;
 }

--- a/src/serial_io/CMakeLists.txt
+++ b/src/serial_io/CMakeLists.txt
@@ -14,6 +14,8 @@
 # -------------------------------------------------------------
 
 set(target_libraries
+  gridpack_math
+  gridpack_environment
   gridpack_timer
   ${GA_LIBRARIES} 
   ${Boost_LIBRARIES} 

--- a/src/serial_io/test/test_goss.cpp
+++ b/src/serial_io/test/test_goss.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <macdecls.h>
 #include "gridpack/utilities/complex.hpp"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/configuration/configuration.hpp"
 #include "gridpack/network/base_network.hpp"
 #include "gridpack/component/base_component.hpp"
@@ -323,7 +324,7 @@ void run (const int &me, const int &nprocs, int argc, char **argv)
 int
 main (int argc, char **argv) 
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   int me(world.rank());
   int nprocs(world.size());

--- a/src/serial_io/test/test_serial_io.cpp
+++ b/src/serial_io/test/test_serial_io.cpp
@@ -7,6 +7,7 @@
 #include "mpi.h"
 #include <vector>
 #include <macdecls.h>
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/utilities/complex.hpp"
 #include "gridpack/network/base_network.hpp"
 #include "gridpack/component/base_component.hpp"
@@ -342,7 +343,7 @@ void run (const int &me, const int &nprocs)
 int
 main (int argc, char **argv) 
 {
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   int me(world.rank());
   int nprocs(world.size());

--- a/src/timer/CMakeLists.txt
+++ b/src/timer/CMakeLists.txt
@@ -23,12 +23,15 @@ add_dependencies(gridpack_timer external_build)
 if (GRIDPACK_LIB_LINK_LIBRARIES)
   target_link_libraries(gridpack_timer
     gridpack_parallel
+    gridpack_environment
     )
 endif()
 
 set(target_libraries
     gridpack_timer
     gridpack_parallel
+    gridpack_math
+    gridpack_environment
     ${GA_LIBRARIES}
     ${Boost_LIBRARIES}
     ${MPI_CXX_LIBRARIES}

--- a/src/timer/test/test_timer.cpp
+++ b/src/timer/test/test_timer.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include "mpi.h"
+#include "gridpack/environment/environment.hpp"
 #include "gridpack/parallel/distributed.hpp"
 #include "gridpack/timer/coarse_timer.hpp"
 #include "gridpack/timer/local_timer.hpp"
@@ -112,7 +113,7 @@ bool init_function(void)
 int main (int argc, char **argv) {
 
   // Initialize parallel environment
-  gridpack::parallel::Environment env(argc, argv);
+  gridpack::Environment env(argc, argv);
   gridpack::parallel::Communicator world;
   int me = world.rank();
   if (me == 0) {


### PR DESCRIPTION
This change merges the contents parallel::Environment into gridpack::Environment. Any use of parallel::Environment is replaced by gridpack::Environment. The tests,
examples, and other files where parallel::Environenment are updated.