### PR TITLE
Changes for updating to PETSc 3.16.2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,27 +287,30 @@ include_directories(AFTER ${Boost_INCLUDE_DIRS})
 # compiled with C++ complex support.
 # -------------------------------------------------------------
 message(STATUS "Checking PETSc ...")
-find_package (PETSc REQUIRED)
+include(FindPkgConfig)
+# Include petsc package path in pkg_config_path                                                                      
+set(ENV{PKG_CONFIG_PATH} ${PETSC_DIR}/lib/pkgconfig:${PETSC_DIR}/${PETSC_ARCH}/lib/pkgconfig                         
+)
+pkg_check_modules(PETSC REQUIRED IMPORTED_TARGET PETSc)
 message(STATUS "Using PETSc version ${PETSC_VERSION}")
 
-if (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/conf/PETScConfig.cmake")
-  include("${PETSC_DIR}/${PETSC_ARCH}/conf/PETScConfig.cmake")
-elseif (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/PETScConfig.cmake")
-  include("${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/PETScConfig.cmake")
-elseif (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/PETScBuildInternal.cmake")
-  include("${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/PETScBuildInternal.cmake")
-else()
-  message(FATAL_ERROR "PETSc found, but CMake configuration for PETSc installation not found?")
-endif()
+if(EXISTS "${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h")                                                        
+  set(petscconf "${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h")
+elseif(EXISTS "${PETSC_DIR}/include/petscconf.h")                                                                
+  set(petscconf "${PETSC_DIR}/include/petscconf.h")
+ else()                                                                                                             
+  message(FATAL_ERROR "Could not find PETSc configuration header file petscconf.h")
+endif()  
 
-message(STATUS "PETSC_LIBRARY_SINGLE: ${PETSC_LIBRARY_SINGLE}")
-
-
-# checks 
-
-if (NOT PETSC_HAVE_MPI)
-  message(FATAL_ERROR "PETSc installation is not parallel (--with-mpi=1)")
-endif()
+# checks
+# define PETSc variables                                                                                           
+include(CheckSymbolExists)                                                                                         
+check_symbol_exists(PETSC_HAVE_PARMETIS ${petscconf} PETSC_HAVE_PARMETIS)                                          
+check_symbol_exists(PETSC_USE_REAL_DOUBLE ${petscconf} PETSC_USE_REAL_DOUBLE)                                      
+check_symbol_exists(PETSC_USE_COMPLEX ${petscconf} PETSC_USE_COMPLEX)                                              
+check_symbol_exists(PETSC_LANGUAGE_CXX ${petscconf} PETSC_CLANGUAGE_Cxx)                                           
+check_symbol_exists(PETSC_HAVE_SUPERLU_DIST ${petscconf} PETSC_HAVE_SUPERLU_DIST)                                  
+check_symbol_exists(PETSC_HAVE_MUMPS ${petscconf} PETSC_HAVE_MUMPS)                  
 
 # PETSc can be compiled for double precsion (--with-precision=double)
 # complex (--with-scalar-type=complex) or real

--- a/src/applications/contingency_analysis/CMakeLists.txt
+++ b/src/applications/contingency_analysis/CMakeLists.txt
@@ -29,7 +29,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/development/dynamic_simulation_implicit/CMakeLists.txt
+++ b/src/applications/development/dynamic_simulation_implicit/CMakeLists.txt
@@ -25,8 +25,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (GA_FOUND)

--- a/src/applications/development/dynamic_simulation_reduced_y/CMakeLists.txt
+++ b/src/applications/development/dynamic_simulation_reduced_y/CMakeLists.txt
@@ -42,7 +42,6 @@ set (target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES})
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/applications/development/powerflow2/CMakeLists.txt
+++ b/src/applications/development/powerflow2/CMakeLists.txt
@@ -27,7 +27,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/dynamic_simulation_full_y/CMakeLists.txt
+++ b/src/applications/dynamic_simulation_full_y/CMakeLists.txt
@@ -27,7 +27,6 @@ set(target_libraries
     gridpack_configuration
     gridpack_timer
     gridpack_parallel
-    ${PETSC_LIBRARIES}
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}

--- a/src/applications/examples/contingency_analysis/CMakeLists.txt
+++ b/src/applications/examples/contingency_analysis/CMakeLists.txt
@@ -28,7 +28,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/examples/hello_world/CMakeLists.txt
+++ b/src/applications/examples/hello_world/CMakeLists.txt
@@ -25,8 +25,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 if (GOSS_DIR)
   set(target_libraries

--- a/src/applications/examples/powerflow/CMakeLists.txt
+++ b/src/applications/examples/powerflow/CMakeLists.txt
@@ -27,7 +27,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/examples/resistor_grid/CMakeLists.txt
+++ b/src/applications/examples/resistor_grid/CMakeLists.txt
@@ -25,8 +25,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 if (GOSS_DIR)
   set(target_libraries

--- a/src/applications/hadrec/CMakeLists.txt
+++ b/src/applications/hadrec/CMakeLists.txt
@@ -30,7 +30,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/kalman_ds/CMakeLists.txt
+++ b/src/applications/kalman_ds/CMakeLists.txt
@@ -28,7 +28,6 @@ set(target_libraries
     gridpack_configuration
     gridpack_timer
     gridpack_parallel
-    ${PETSC_LIBRARIES}
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}

--- a/src/applications/modules/dynamic_simulation/CMakeLists.txt
+++ b/src/applications/modules/dynamic_simulation/CMakeLists.txt
@@ -24,7 +24,6 @@ set(target_libraries
     gridpack_math
     gridpack_configuration
     gridpack_timer
-    ${PETSC_LIBRARIES}
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}

--- a/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
+++ b/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
@@ -28,8 +28,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 if (GOSS_DIR)
   set(target_libraries

--- a/src/applications/modules/hadrec/CMakeLists.txt
+++ b/src/applications/modules/hadrec/CMakeLists.txt
@@ -29,8 +29,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (GA_FOUND)

--- a/src/applications/modules/kalman_ds/CMakeLists.txt
+++ b/src/applications/modules/kalman_ds/CMakeLists.txt
@@ -26,8 +26,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (GA_FOUND)

--- a/src/applications/modules/powerflow/CMakeLists.txt
+++ b/src/applications/modules/powerflow/CMakeLists.txt
@@ -27,8 +27,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (GA_FOUND)

--- a/src/applications/modules/state_estimation/CMakeLists.txt
+++ b/src/applications/modules/state_estimation/CMakeLists.txt
@@ -25,8 +25,7 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
-    ${PETSC_LIBRARIES})
+    ${MPI_CXX_LIBRARIES})
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 if (GA_FOUND)

--- a/src/applications/powerflow/CMakeLists.txt
+++ b/src/applications/powerflow/CMakeLists.txt
@@ -28,7 +28,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/rtpr/CMakeLists.txt
+++ b/src/applications/rtpr/CMakeLists.txt
@@ -31,7 +31,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/applications/state_estimation/CMakeLists.txt
+++ b/src/applications/state_estimation/CMakeLists.txt
@@ -28,7 +28,6 @@ set(target_libraries
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}
-    ${PETSC_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
     )
 

--- a/src/mapper/CMakeLists.txt
+++ b/src/mapper/CMakeLists.txt
@@ -18,7 +18,6 @@ set(target_libraries
   ${GA_LIBRARIES} 
   ${Boost_LIBRARIES} 
   ${MPI_CXX_LIBRARIES}
-  ${PETSC_LIBRARIES}
 )
 
 set(target_libraries 

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -91,7 +91,7 @@ if (PETSC_FOUND)
     petsc/petsc_dae_solver.cpp
     )  
 
-  set(target_libraries ${PETSC_LIBRARIES} ${target_libraries})
+  set(target_libraries PkgConfig::PETSC ${target_libraries})
 
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/gridpack.xml"
@@ -139,10 +139,14 @@ gridpack_set_library_version(gridpack_math)
 add_dependencies(gridpack_math external_build)
 
 target_link_libraries(gridpack_math 
+  PUBLIC
   gridpack_configuration
+  PUBLIC
   gridpack_timer
+  PUBLIC
   gridpack_parallel
-  ${PETSC_LIBRARIES}
+  PUBLIC
+  PkgConfig::PETSC
   )
 
 # -------------------------------------------------------------

--- a/src/optimization/CMakeLists.txt
+++ b/src/optimization/CMakeLists.txt
@@ -64,7 +64,6 @@ set(target_libraries
   ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
   ${GA_LIBRARIES} 
   ${Boost_LIBRARIES} 
-  ${PETSC_LIBRARIES}
   ${MPI_CXX_LIBRARIES}
 )
 


### PR DESCRIPTION
This branch updates GridPACK to be compatible with PETSc 3.16.2 The only changes required were to the build system. There were no changes to the GridPACK source code needed. 

Note: **This change removes the need of using Jed's cmake files. Instead if uses the pkgconfig utility to find PETSc. When PETSc is built successfully, it creates a package configuration file in <petsc_install>/lib/pkgconfig. We use the file to set up PETSc specifics in GridPACK's CMake file. Also, instead of PETScConfig.cmake petscconf.h is used that has all the PETSc flags declared.

@bjpalmer