### PR TITLE
Control blocks and new dynamic models - SEXS, GAST, and HYGOV

### DIFF
--- a/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
+++ b/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
@@ -11,6 +11,7 @@
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
 # Last Change: 2019-08-16 13:45:12 d3g096
+# Last Change: 2022-11-07 Shrirang Abhyankar - added sexs, gast, and hygov models
 # -------------------------------------------------------------
 
 
@@ -100,6 +101,7 @@ add_library(gridpack_dynamic_simulation_full_y_module
   model_classes/cblock.cpp
   model_classes/sexs.cpp
   model_classes/gast.cpp
+  model_classes/hygov.cpp
 )
 
 gridpack_set_library_version(gridpack_dynamic_simulation_full_y_module)
@@ -162,6 +164,7 @@ install(FILES
   model_classes/cblock.hpp
   model_classes/sexs.hpp
   model_classes/gast.hpp
+  model_classes/hygov.hpp
   DESTINATION include/gridpack/applications/modules/dynamic_simulation_full_y
 )
 
@@ -207,6 +210,7 @@ install(FILES
   model_classes/cblock.hpp
   model_classes/sexs.hpp
   model_classes/gast.hpp
+  model_classes/hygov.hpp
   DESTINATION include/gridpack/applications/modules/dynamic_simulation_full_y/model_classes
 ) 	      
 

--- a/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
+++ b/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(gridpack_dynamic_simulation_full_y_module
   model_classes/repca1.cpp
   model_classes/cblock.cpp
   model_classes/sexs.cpp
+  model_classes/gast.cpp
 )
 
 gridpack_set_library_version(gridpack_dynamic_simulation_full_y_module)
@@ -160,6 +161,7 @@ install(FILES
   model_classes/repca1.hpp
   model_classes/cblock.hpp
   model_classes/sexs.hpp
+  model_classes/gast.hpp
   DESTINATION include/gridpack/applications/modules/dynamic_simulation_full_y
 )
 
@@ -204,6 +206,7 @@ install(FILES
   model_classes/repca1.hpp
   model_classes/cblock.hpp
   model_classes/sexs.hpp
+  model_classes/gast.hpp
   DESTINATION include/gridpack/applications/modules/dynamic_simulation_full_y/model_classes
 ) 	      
 

--- a/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
+++ b/src/applications/modules/dynamic_simulation_full_y/CMakeLists.txt
@@ -97,6 +97,8 @@ add_library(gridpack_dynamic_simulation_full_y_module
   model_classes/regca1.cpp
   model_classes/reeca1.cpp
   model_classes/repca1.cpp
+  model_classes/cblock.cpp
+  model_classes/sexs.cpp
 )
 
 gridpack_set_library_version(gridpack_dynamic_simulation_full_y_module)
@@ -156,6 +158,8 @@ install(FILES
   model_classes/regca1.hpp
   model_classes/reeca1.hpp
   model_classes/repca1.hpp
+  model_classes/cblock.hpp
+  model_classes/sexs.hpp
   DESTINATION include/gridpack/applications/modules/dynamic_simulation_full_y
 )
 
@@ -198,8 +202,10 @@ install(FILES
   model_classes/regca1.hpp
   model_classes/reeca1.hpp
   model_classes/repca1.hpp
+  model_classes/cblock.hpp
+  model_classes/sexs.hpp
   DESTINATION include/gridpack/applications/modules/dynamic_simulation_full_y/model_classes
-)
+) 	      
 
 install(TARGETS 
   gridpack_dynamic_simulation_full_y_module

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -586,7 +586,6 @@ void gridpack::dynamic_simulation::DSFullBus::initDSVect(double ts)
       p_eprime_s1.push_back(0.0);
       p_INorton.push_back(0.0);
 #else
-      printf("\ngen %d i = %d,  ngen = %d:***********\n", getOriginalIndex(),i,p_ngen);
       p_generators[i]->init(p_voltage,p_angle, ts);
 #endif
     }

--- a/src/applications/modules/dynamic_simulation_full_y/generator_factory.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/generator_factory.cpp
@@ -30,6 +30,7 @@
 #include "tgov1.hpp"
 #include "sexs.hpp"
 #include "gast.hpp"
+#include "hygov.hpp"
 
 #include <stdio.h>
 
@@ -158,6 +159,11 @@ gridpack::dynamic_simulation::GeneratorFactory::createGovernorModel(
   } else if (type == "GAST") {
     gridpack::dynamic_simulation::GastModel *tmp;
     tmp =  new gridpack::dynamic_simulation::GastModel;
+    ret =
+      dynamic_cast<gridpack::dynamic_simulation::BaseGovernorModel*>(tmp);
+  } else if (type == "HYGOV") {
+    gridpack::dynamic_simulation::HygovModel *tmp;
+    tmp =  new gridpack::dynamic_simulation::HygovModel;
     ret =
       dynamic_cast<gridpack::dynamic_simulation::BaseGovernorModel*>(tmp);
   } else if (type == "WSHYGP") {

--- a/src/applications/modules/dynamic_simulation_full_y/generator_factory.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/generator_factory.cpp
@@ -29,6 +29,7 @@
 #include "psssim.hpp"
 #include "tgov1.hpp"
 #include "sexs.hpp"
+#include "gast.hpp"
 
 #include <stdio.h>
 
@@ -150,9 +151,13 @@ gridpack::dynamic_simulation::GeneratorFactory::createGovernorModel(
     ret =
       dynamic_cast<gridpack::dynamic_simulation::BaseGovernorModel*>(tmp);
   } else if (type == "TGOV1") {
-	//printf("----------------!!!!---debug, one TOGV1 model in the dyr file\n");
     gridpack::dynamic_simulation::Tgov1Model *tmp;
     tmp =  new gridpack::dynamic_simulation::Tgov1Model;
+    ret =
+      dynamic_cast<gridpack::dynamic_simulation::BaseGovernorModel*>(tmp);
+  } else if (type == "GAST") {
+    gridpack::dynamic_simulation::GastModel *tmp;
+    tmp =  new gridpack::dynamic_simulation::GastModel;
     ret =
       dynamic_cast<gridpack::dynamic_simulation::BaseGovernorModel*>(tmp);
   } else if (type == "WSHYGP") {

--- a/src/applications/modules/dynamic_simulation_full_y/generator_factory.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/generator_factory.cpp
@@ -28,6 +28,7 @@
 #include "wshygp.hpp"
 #include "psssim.hpp"
 #include "tgov1.hpp"
+#include "sexs.hpp"
 
 #include <stdio.h>
 
@@ -107,6 +108,11 @@ gridpack::dynamic_simulation::GeneratorFactory::createExciterModel(
     gridpack::dynamic_simulation::Exdc1Model *tmp;
     tmp =  new gridpack::dynamic_simulation::Exdc1Model;
     ret =
+      dynamic_cast<gridpack::dynamic_simulation::BaseExciterModel*>(tmp);
+  } else if (type == "SEXS") {
+      gridpack::dynamic_simulation::SexsModel *tmp;
+      tmp =  new gridpack::dynamic_simulation::SexsModel;
+      ret =
       dynamic_cast<gridpack::dynamic_simulation::BaseExciterModel*>(tmp);
   } else if (type == "ESST1A") {
     gridpack::dynamic_simulation::Esst1aModel *tmp;

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
@@ -107,6 +107,33 @@ void Cblock::init(double u, double y)
   }
 }
 
+double Cblock::init_given_u(double u)
+{
+  double y;
+  if(fabs(p_A[0]) < 1e-10) {
+    y = u;
+    x[0] = u;
+  } else {
+    x[0] = -p_B[0]/p_A[0]*u;
+    y    = p_C[0]*x[0] + p_D[0]*u;
+  }
+  return y;
+}
+
+double Cblock::init_given_y(double y)
+{
+  double u;
+  if(fabs(p_A[0]) < 1e-10) {
+    u = y;
+    x[0] = u;
+  } else {
+    u = y/(p_D[0] - p_C[0]*p_B[0]/p_A[0]);
+    x[0] = -p_B[0]/p_A[0]*u;
+  }
+  return u;
+}
+
+
 double Cblock::getstate(IntegrationStage stage)
 {
   double xout;

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
@@ -110,9 +110,9 @@ void Cblock::init(double u, double y)
 double Cblock::init_given_u(double u)
 {
   double y;
-  if(fabs(p_A[0]) < 1e-10) {
-    y = u;
-    x[0] = u;
+  if(fabs(p_B[0]) < 1e-10) {
+    x[0] = 0;
+    y = p_C[0]*x[0] + p_D[0]*u;
   } else {
     x[0] = -p_B[0]/p_A[0]*u;
     y    = p_C[0]*x[0] + p_D[0]*u;
@@ -124,8 +124,8 @@ double Cblock::init_given_y(double y)
 {
   double u;
   if(fabs(p_A[0]) < 1e-10) {
-    u = y;
-    x[0] = u;
+    u = 0;
+    x[0] = y;
   } else {
     u = y/(p_D[0] - p_C[0]*p_B[0]/p_A[0]);
     x[0] = -p_B[0]/p_A[0]*u;

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
@@ -1,0 +1,254 @@
+#include "cblock.hpp"
+
+Cblock::Cblock()
+{
+  p_order = 1; // For future use
+  p_xmin  = p_ymin = -1000.0;
+  p_xmax  = p_ymax =  1000.0;
+}
+
+Cblock::~Cblock(void)
+{
+}
+
+/* Set the coefficients for the transfer function
+
+  Y(s)    b0s + b1
+ ----- = --------------
+  U(s)    a0s + a1
+
+  a = [a0,a1], b = [b0,b1]
+ */
+void Cblock::setcoeffs(double *a,double *b)
+{
+  p_A[0] = -a[1]/a[0];
+  p_B[0] = (b[1] - a[1]*b[0])/a[0];
+  p_C[0] = 1.0;
+  p_D[0] = b[0]/a[0];
+}
+
+void Cblock::setxlimits(double xmin,double xmax)
+{
+  p_xmin = xmin;
+  p_xmax = xmax;
+}
+
+void Cblock::setylimits(double ymin,double ymax)
+{
+  p_ymin = ymin;
+  p_ymax = ymax;
+
+}
+
+double Cblock::getderivative(double x, double u)
+{
+  return p_A[0]*x + p_B[0]*u;
+}
+
+double Cblock::updatestate(double u,double dt,double xmin,double xmax,IntegrationStage stage)
+{
+  double xout,dx_dt;
+
+  if(stage == PREDICTOR) {
+    p_dxdt[0] = getderivative(x[0],u);
+    xout = x[0] + dt*p_dxdt[0];
+    xout = std::max(xmin,std::min(xout,xmax));
+    p_xhat[0] = xout;
+  }
+
+  if(stage == CORRECTOR) {
+    dx_dt = getderivative(p_xhat[0],u);
+    xout = x[0] + 0.5*dt*(p_dxdt[0] + dx_dt);
+    xout = std::max(xmin,std::min(xout,xmax));
+    x[0] = xout;
+  }
+
+  return xout;
+}
+
+double Cblock::updatestate(double u,double dt,IntegrationStage stage)
+{
+  double xout;
+
+  xout = updatestate(u,dt,p_xmin,p_xmax,stage);
+
+  return xout;
+}
+
+double Cblock::getoutput(double u,double dt,double xmin,double xmax,double ymin,double ymax,IntegrationStage stage)
+{
+  double x,y;
+
+  x = updatestate(u,dt,xmin,xmax,stage);
+  
+  y = p_C[0]*x + p_D[0]*u;
+
+  y = std::max(ymin,std::min(y,ymax));
+
+  return y;
+}
+
+double Cblock::getoutput(double u,double dt,IntegrationStage stage)
+{
+  double y;
+
+  y = getoutput(u,dt,p_xmin,p_xmax,p_ymin,p_ymax,stage);
+
+  return y;
+}
+
+void Cblock::init(double u, double y)
+{
+  double uout;
+  if(fabs(p_A[0]) < 1e-10) x[0] = y;
+  else {
+    uout = y/(p_D[0] - p_C[0]*p_B[0]/p_A[0]);
+    x[0] = -p_B[0]/p_A[0]*uout;
+  }
+}
+
+double Cblock::getstate(IntegrationStage stage)
+{
+  double xout;
+  if(stage == PREDICTOR) xout = p_xhat[0];
+  if(stage == CORRECTOR) xout = x[0];
+  return xout;
+}
+
+// ------------------------------------
+// PI Controller
+// ------------------------------------
+
+PIControl::PIControl(void): Cblock()
+{
+}
+
+void PIControl::setparams(double Kp, double Ki)
+{
+  double a[2],b[2];
+
+  // Parameters for state-space representation
+  // Transfer funtion is
+  // Kp + Ki/s => (sKp + Ki)/s
+  // In standard form, this will be
+  // (sKp + Ki)/(s + 0)
+
+  b[0] = Kp;
+  b[1] = Ki;
+  a[0] = 1.0;
+  a[1] = 0.0;
+
+  setcoeffs(a,b);
+  setxlimits(-1000.0,1000.0);
+  setylimits(-1000.0,1000.0);
+
+}
+void PIControl::setparams(double Kp, double Ki,double xmin,double xmax,double ymin,double ymax)
+{
+  setparams(Kp,Ki);
+  setxlimits(xmin,xmax);
+  setylimits(ymin,ymax);
+}
+
+// ------------------------------------
+// Filter
+// ------------------------------------
+
+Filter::Filter(void)
+{
+  setxlimits(-1000.0,1000.0);
+  setylimits(-1000.0,1000.0);
+}
+
+void Filter::setparams(double K,double T)
+{
+  double a[2],b[2];
+
+  // Parameters for state-space representation
+  // Transfer funtion is
+  // K/(1 + sT)
+  // In standard form, this will be
+  // (s*0 + K)/(sT + 1)
+
+  b[0] = 0;
+  b[1] = K;
+  a[0] = T;
+  a[1] = 1;
+
+  setcoeffs(a,b);
+  setxlimits(-1000.0,1000.0);
+  setylimits(-1000.0,1000.0);
+}
+
+void Filter::setparams(double K,double T,double xmin,double xmax,double ymin,double ymax)
+{
+  setparams(K,T);
+  setxlimits(xmin,xmax);
+  setylimits(ymin,ymax);
+}
+
+// ------------------------------------
+// Lead lag
+// ------------------------------------
+
+LeadLag::LeadLag(void)
+{
+  setxlimits(-1000.0,1000.0);
+  setylimits(-1000.0,1000.0);
+}
+
+void LeadLag::setparams(double TA,double TB)
+{
+  double a[2],b[2];
+
+  // Parameters for state-space representation
+  // Transfer funtion is
+  // (1 + sTA)/(1 + sTB)
+
+  b[0] = TA;
+  b[1] = 1;
+  a[0] = TB;
+  a[1] = 1;
+
+  setcoeffs(a,b);
+  setxlimits(-1000.0,1000.0);
+  setylimits(-1000.0,1000.0);
+}
+
+void LeadLag::setparams(double TA,double TB,double xmin,double xmax,double ymin,double ymax)
+{
+  setparams(TA,TB);
+  setxlimits(xmin,xmax);
+  setylimits(ymin,ymax);
+}
+
+
+// ------------------------------------
+// Integrator
+// ------------------------------------
+
+Integrator::Integrator(void)
+{
+}
+
+void Integrator::setparams(double T)
+{
+  double a[2],b[2];
+
+  // Parameters for state-space representation
+  // Transfer funtion is
+  // 1/(sT)
+  // In standard form, this will be
+  // (s*0 + 1)/(sT + 0)
+
+  b[0] = 0;
+  b[1] = 1;
+  a[0] = T;
+  a[1] = 0;
+
+  setcoeffs(a,b);
+  setxlimits(-1000.0,1000.0);
+  setylimits(-1000.0,1000.0);
+}
+
+

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.cpp
@@ -45,7 +45,7 @@ double Cblock::getderivative(double x, double u)
   return p_A[0]*x + p_B[0]*u;
 }
 
-double Cblock::updatestate(double u,double dt,double xmin,double xmax,IntegrationStage stage)
+void Cblock::updatestate(double u,double dt,double xmin,double xmax,IntegrationStage stage)
 {
   double xout,dx_dt;
 
@@ -62,37 +62,37 @@ double Cblock::updatestate(double u,double dt,double xmin,double xmax,Integratio
     xout = std::max(xmin,std::min(xout,xmax));
     x[0] = xout;
   }
-
-  return xout;
 }
 
-double Cblock::updatestate(double u,double dt,IntegrationStage stage)
+void Cblock::updatestate(double u,double dt,IntegrationStage stage)
 {
-  double xout;
-
-  xout = updatestate(u,dt,p_xmin,p_xmax,stage);
-
-  return xout;
+  updatestate(u,dt,p_xmin,p_xmax,stage);
 }
 
-double Cblock::getoutput(double u,double dt,double xmin,double xmax,double ymin,double ymax,IntegrationStage stage)
+double Cblock::getoutput(double u,double dt,double xmin,double xmax,double ymin,double ymax,IntegrationStage stage, bool dostateupdate)
 {
-  double x,y;
+  double x_n,y_n,x_n1;
 
-  x = updatestate(u,dt,xmin,xmax,stage);
+  if(stage == PREDICTOR) x_n = x[0];
+  else x_n = p_xhat[0];
   
-  y = p_C[0]*x + p_D[0]*u;
+  y_n = p_C[0]*x_n + p_D[0]*u;
 
-  y = std::max(ymin,std::min(y,ymax));
+  y_n = std::max(ymin,std::min(y_n,ymax));
 
-  return y;
+  // State update is done after output
+  if(dostateupdate) {
+    updatestate(u,dt,xmin,xmax,stage);
+  }
+
+  return y_n;
 }
 
-double Cblock::getoutput(double u,double dt,IntegrationStage stage)
+double Cblock::getoutput(double u,double dt,IntegrationStage stage,bool dostateupdate)
 {
   double y;
 
-  y = getoutput(u,dt,p_xmin,p_xmax,p_ymin,p_ymax,stage);
+  y = getoutput(u,dt,p_xmin,p_xmax,p_ymin,p_ymax,stage,dostateupdate);
 
   return y;
 }

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.hpp
@@ -213,6 +213,26 @@ class Cblock
   void init(double u, double y);
 
   /**
+     INIT_GIVEN_U - Initializes the control block - calculates x[0] given input u
+
+     Inputs:
+       u           Control block input u
+     Outputs:
+       y           Expected output for the control block given the input u
+  **/
+  double init_given_u(double u);
+
+  /**
+     INIT_GIVEN_Y - Initializes the control block - calculates x[0] given output y
+
+     Inputs:
+       y           Control block output y
+     Outputs:
+       u           Expected input for the control block given the output y
+  **/
+  double init_given_y(double y);
+
+  /**
      GETOUPUT - Returns output y of the control block
 
      Inputs:

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/cblock.hpp
@@ -1,0 +1,489 @@
+/**
+ * @file cblock.hpp
+ * @brief Header file defining the public API for linear control block
+ *
+ */
+
+#ifndef CBLOCK_HPP
+#define CBLOCK_HPP
+
+#include <math.h>
+#include <algorithm>
+
+/**
+  INTEGRATIONSTAGE - Stage in integration
+
+  Enum to specify Integration calculation stage.
+*/
+typedef enum {
+  PREDICTOR, // Predictor update
+  CORRECTOR  // Corrector update
+}IntegrationStage;
+
+
+/*
+  Linear control block base class - This is the base class for linear blocks. All 
+  control blocks inherit from this class. It expresses a first order linear transfer
+  function in observable canonical form to obtain a first order state-space 
+  representation. The state x and output y can be bounded by limits.
+
+  Linear control block:
+  input  : u 
+  output : y
+  state  : x
+      
+                 xmax
+                ----
+               /             ymax
+              /             -----
+        -------------      /
+        | b0s + b1  |     /
+  u ----| --------- |----------- y
+        | a0s + a1  |    /
+        -------------   /
+             /       ---
+            /        ymin
+        ----
+        xmin
+
+
+  For a first order transfer function, 
+
+  Y(s)    b0s + b1
+  ----- = ----------
+  U(s)    a0s + a1
+
+  The equivalent state-space representation in the observable canonical form is given by
+
+  dx_dt = Ax + Bu
+    y   = Cx + Du
+
+  here u,x,y \in R^1 
+
+  A = -a1/a0, B = (b1 - a1b0)/a0, C = 1, D = b0/a0
+
+  Output:
+   y = Cx + D*u,  ymin <= y <= ymax
+
+*/ 
+class Cblock
+{
+ protected:
+  double p_A[1]; /* A */
+  double p_B[1]; /* B */
+  double p_C[1]; /* C */
+  double p_D[1]; /* D */
+
+  double p_dxdt[1];   /* State derivative */
+  double p_xhat[1];   /* Predictor stage x */
+
+  // p_order is kept for future extensions if and
+  // when the order of the transfer function > 1
+  int    p_order; /* order of the control block */
+
+  double p_xmax,p_xmin; /* Max./Min. limits on state X */
+  double p_ymax,p_ymin; /* Max./Min. limits on output Y */
+
+  /**
+     UPDATESTATE - Updates the linear control block state variable
+
+     Inputs:
+       u               Input to the control block
+       dt              Integration time-step
+       IntegrationStage  Stage of integration mode calculation, PREDICTOR or CORRECTOR
+
+     Output:
+       x               Control state variable
+                         x = \hat{x}_{n+1} for PREDICTOR stage
+			 x = x_{n+1}       for CORRECTOR stage
+
+     Note: State update calculation
+       PREDICTOR (Forward Euler):
+
+         \hat{x}_{n+1} = x_{n} + dt*dx_dt(x_{n},u_{n})
+
+       CORRECTOR (Trapezoidal):
+
+         x_{n+1} = x_{n} + 0.5*dt*(dx_dt(x_{n}) + dx_dt(\hat{x}_{n+1},u_{n+1}))
+
+
+    Note here that GridLab-D does a network solve after every predictor/corrector
+    call. So, during the corrector stage the input u is updated (u_{n+1}) 
+  **/
+  double updatestate(double u, double dt,IntegrationStage stage);
+
+  /**
+     UPDATESTATE - Update linear control block state variable enforcing limits
+
+     Inputs:
+       u               Input to the control block
+       dt              Integration time-step
+       xmin            Min. limiter for state x
+       xmax            Max. limiter for state x
+       IntegrationStage  Stage of integration mode calculation, PREDICTOR or CORRECTOR
+
+     Output:
+       x               Control state variable
+                         x = \hat{x}_{n+1} for PREDICTOR stage
+			 x = x_{n+1}       for CORRECTOR stage
+
+     Note: State update calculation
+       PREDICTOR (Forward Euler):
+
+         \hat{x}_{n+1} = x_{n} + dt*dx_dt(x_{n},u_{n})
+
+	 \hat{x}_{n+1} = max(xmin,min(\hat{x}_{n+1},xmax)
+
+       CORRECTOR (Trapezoidal):
+
+         x_{n+1} = x_{n} + 0.5*dt*(dx_dt(x_{n}) + dx_dt(\hat{x}_{n+1},u_{n+1})) 
+
+	 x_{n+1} = max(xmin,min(x_{n+1},xmax)
+
+    Note here that GridLab-D does a network solve after every predictor/corrector
+    call. So, during the corrector stage the input u is updated (u_{n+1}) 
+  **/
+  double updatestate(double u, double dt,double xmin, double xmax, IntegrationStage stage);
+
+  /**
+     GETDERIVATIVE - Returns the time derivative of the linear control block state variable
+
+     Inputs:
+       x          State variable
+       u          Control block input
+
+     Outputs:
+       dx_dt      State derivative
+  **/
+  double getderivative(double x,double u);
+
+ public:
+  Cblock();
+
+  // This is made public so that it can be accessed via
+  // PADDR() method
+  double x[1];      /* State variable x */
+
+  /**
+     SETCOEFFS - Sets the coefficients a,b for the control block transfer function
+
+     Inputs:
+       a           An array of size 2,[a0,a1] for setting coefficients for the denominator
+       b           An array of size 2,[b0,b1] for setting coefficients for the numerator
+
+     Notes:
+       The transfer function for the linear control block is expressed in the form
+       Y(s)   b0*s + b1
+       --- = -----------
+       U(s)   a0*s + a1
+
+       The user is expected to provide the coefficients for the transfer function in arrays a and b
+
+       As an example, let's assume the transfer function is (2s + 3)/(s + 2), then the arrays a and b
+       passed to setcoeffs would be a = [1,2] and b = [2,3]
+  **/
+  void setcoeffs(double *a,double *b);
+
+
+  /**
+     SETXLIMITS - Sets limits for the state variable x
+
+     Inputs:
+       xmin          Min. limit for x
+       xmax          Max. limit for x
+  **/
+  void setxlimits(double xmin, double xmax);
+
+  /**
+     SETYLIMITS - Sets limits for output y
+
+     Inputs:
+       ymin          Min. limit for y
+       ymax          Max. limit for y
+  **/
+  void setylimits(double ymin, double ymax);
+
+  /**
+     INIT - Initializes the control block - calculates x[0]
+
+     Inputs:
+       u           Control block input u (u[0])
+       y           Control block (expected) output y (y[0])
+  **/
+  void init(double u, double y);
+
+  /**
+     GETOUPUT - Returns output y of the control block
+
+     Inputs:
+       u               Input to the control block
+       dt              Integration time-step
+       IntegrationStage  Stage of integration mode calculation, PREDICTOR or CORRECTOR
+
+     Output:
+       y               Control block output
+
+     Note: Output calculation
+       PREDICTOR :
+	 y_{n+1} = C\hat{x}_{n+1} + Du_{n}
+
+       CORRECTOR :
+
+	 y_{n+1} = Cx_{n+1} + Du_{n+1}
+
+    Note here that GridLab-D does a network solve after every predictor/corrector
+    call. So, during the corrector stage the input u is updated (u_{n+1}) 
+  **/
+  double getoutput(double u,double dt,IntegrationStage stage);
+
+  /**
+     GETOUTPUT - Returns control block output y enforcing limits on state and output.
+
+     Inputs:
+       u               Input to the control block
+       dt              Integration time-step
+       xmin            Min. limit for state variable
+       xmax            Max. limit for state variable
+       ymin            Min. limit for output y
+       ymax            Max. limit for output y
+       IntegrationStage  Stage of integration mode calculation, PREDICTOR or CORRECTOR
+
+     Output:
+       y               Control block output
+
+     Note: Output calculation
+       PREDICTOR :
+
+	 y_{n+1} = C\hat{x}_{n+1} + Du_{n}
+
+	 y_{n+1} = max(ymin,min(y_{n+1},ymax)
+
+       CORRECTOR :
+	 y_{n+1} = Cx_{n+1} + Du_{n+1}
+
+	 y_{n+1} = max(ymin,min(y_{n+1},ymax)
+
+    Note here that GridLab-D does a network solve after every predictor/corrector
+    call. So, during the corrector stage the input u is updated (u_{n+1}) 
+  **/
+  double getoutput(double u,double dt,double xmin, double xmax, double ymin, double ymax, IntegrationStage stage);
+
+  /**
+     GETSTATE - Returns the internal state variable x for the control block
+
+     Input:
+       stage          Stage of integration mode calculation, PREDICTOR or CORRECTOR
+
+     Output:
+       x              Control block state variable
+  **/
+  double getstate(IntegrationStage stage);
+
+  ~Cblock(void);
+};
+
+/*
+  PI control block:
+  input  : u 
+  output : y
+  state  : x (integrator)
+      
+                 xmax
+                ----
+               /             ymax
+              /             -----
+        -------------      /
+        |           |     /
+  u ----| Kp + Ki/s |----------- y
+        |           |    /
+        -------------   /
+             /       ---
+            /        ymin
+        ----
+        xmin
+
+   Differential equation:
+       dx_dt = Ki*u
+
+   Output:
+    y = x + Kp*u,  ymin <= y <= ymax
+
+*/
+class PIControl: public Cblock
+{
+ public:
+  PIControl();
+
+  /**
+     SETPARAMS - Set the PI controller gains
+
+     INPUTS:
+       Kp         Proportional gain
+       Ki         Integral gain
+  **/
+  void setparams(double Kp, double Ki);
+
+  /**
+     SETPARAMS - Set the PI controller gains and limits
+
+     INPUTS:
+       Kp         Proportional gain
+       Ki         Integral gain
+       xmin       Min. limit for state variable
+       xmax       Max. limit for state variable
+       ymin       Min. limit for output y
+       ymax       Max. limit for output y
+  **/
+  void setparams(double Kp, double Ki,double xmin,double xmax,double ymin,double ymax);
+};
+
+/*
+  Lead lag control block:
+  input  : u 
+  output : y
+  state  : x (integrator)
+      
+                 xmax
+                ----
+               /             ymax
+              /             -----
+        -------------      /
+        | 1 + sTA   |     /
+  u ----| --------  |----------- y
+        | 1 + sTB   |    /
+        -------------   /
+             /       ---
+            /        ymin
+        ----
+        xmin
+
+   Differential equation:
+       dx_dt = (-1/TB)*x + (1 - TA)*u/TB
+
+   Output:
+    y = x + TA/TB*u,  ymin <= y <= ymax
+
+*/
+class LeadLag: public Cblock
+{
+ public:
+  LeadLag();
+
+  /**
+     SETPARAMS - Set the lead lag time constants
+
+     INPUTS:
+       TA         Denominator time constant
+       TB         Numerator time constant
+  **/
+  void setparams(double TA, double TB);
+
+  /**
+     SETPARAMS - Set the Lead lag controller gains and limits
+
+     INPUTS:
+       TA         Denominator time constant
+       TB         Numerator time constant
+       xmin       Min. limit for state variable
+       xmax       Max. limit for state variable
+       ymin       Min. limit for output y
+       ymax       Max. limit for output y
+  **/
+  void setparams(double TA, double TB,double xmin,double xmax,double ymin,double ymax);
+};
+
+
+/*
+  Filter block:
+  input  : u 
+  output : y
+  state  : x
+      
+                 xmax
+                ----
+               /             ymax
+              /             -----
+        -------------      /
+        |    K      |     /
+  u ----| -------   |----------- y
+        |  1 + sT   |    /
+        -------------   /
+             /       ---
+            /        ymin
+        ----
+        xmin
+
+   Differential equation:
+       dx_dt = (Ku - x)/T
+
+   Output:
+    y = x,  ymin <= y <= ymax
+
+*/
+class Filter: public Cblock
+{
+ public:
+  Filter();
+  Filter(double K,double T);
+  Filter(double K,double T, double xmin, double xmax,double ymin, double ymax);
+
+  /**
+     SETPARAMS - Set the filter gain and time constant
+
+     INPUTS:
+       K         Filter time constant
+       T         Filter time constant
+  **/
+  void setparams(double K, double T);
+
+  /**
+     SETPARAMS - Set the filter gain, time constant and limits
+
+     INPUTS:
+       K          Filter gain
+       T          Filter time constant
+       xmin       Min. limit for state variable
+       xmax       Max. limit for state variable
+       ymin       Min. limit for output y
+       ymax       Max. limit for output y
+  **/
+  void setparams(double K,double T,double xmin,double xmax,double ymin,double ymax);
+};
+
+/*
+  Integrator block:
+  input  : u 
+  output : y
+  state  : x
+                         
+                           
+        -------------      
+        |    1      |     
+  u ----| -------   |----------- y
+        |   sT      |    
+        -------------   
+             
+              
+   Differential equation:
+       dx_dt = u
+
+   Output:
+    y = x
+
+*/
+class Integrator: public Cblock
+{
+ public:
+  Integrator();
+  
+  /**
+     SETPARAMS - Set the Integrator time constant
+
+     INPUTS:
+       T         Integrator time constant
+  **/
+  void setparams(double T);
+};
+
+
+#endif

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.cpp
@@ -96,9 +96,6 @@ void gridpack::dynamic_simulation::ClassicalGenerator::init(double mag,
   //printf("---classical gen init p_pg = %f, p_qg = %f\n", p_pg, p_qg);
   
   //p_mva = p_sbase / p_mva;
-  p_d0 = p_d0 ;
-  p_h = p_h ;
-  p_dtr = p_dtr;
   p_pelect = p_pg;
   double eterm = mag;
   double vi = ang;
@@ -394,7 +391,7 @@ serialWrite(char *string, const int bufsize, const char *signal)
   } else if (!strcmp(signal,"watch")) {
     if (getWatch()) {
       char buf[256];
-      sprintf(buf,", %8d, %2s, %f, %f, %f",p_bus_id, p_ckt.c_str(), real(p_mac_ang_s1),real(p_mac_spd_s1), real(p_eqprime));
+      sprintf(buf,", %f, %f",real(p_mac_ang_s1),real(p_mac_spd_s1));
       if (strlen(buf) <= bufsize) {
         sprintf(string,"%s",buf);
         ret = true;

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.cpp
@@ -111,15 +111,15 @@ void gridpack::dynamic_simulation::GastModel::predictor(double t_inc, bool flag)
   double fuel_valve_block_in = std::min(lv_gate_in1,Pref - droop);
 
   // Fuel valve block
-  double fuel_valve_block_out = fuel_valve_block.getoutput(fuel_valve_block_in,t_inc,PREDICTOR);
+  double fuel_valve_block_out = fuel_valve_block.getoutput(fuel_valve_block_in,t_inc,PREDICTOR,true);
 
   // Fuel flow block
-  double fuel_flow_block_out = fuel_flow_block.getoutput(fuel_valve_block_out,t_inc,PREDICTOR);
+  double fuel_flow_block_out = fuel_flow_block.getoutput(fuel_valve_block_out,t_inc,PREDICTOR,true);
 
   Pmech = fuel_flow_block_out - Dt*delta_w;
 
   // Exhaust temperature block
-  exh_temp_block_out = exh_temp_block.getoutput(fuel_flow_block_out,t_inc,PREDICTOR);
+  exh_temp_block_out = exh_temp_block.getoutput(fuel_flow_block_out,t_inc,PREDICTOR,true);
   
 }
 
@@ -137,15 +137,15 @@ void gridpack::dynamic_simulation::GastModel::corrector(double t_inc, bool flag)
   double fuel_valve_block_in = std::min(lv_gate_in1,Pref - droop);
 
   // Fuel valve block
-  double fuel_valve_block_out = fuel_valve_block.getoutput(fuel_valve_block_in,t_inc,CORRECTOR);
+  double fuel_valve_block_out = fuel_valve_block.getoutput(fuel_valve_block_in,t_inc,CORRECTOR,true);
 
   // Fuel flow block
-  double fuel_flow_block_out = fuel_flow_block.getoutput(fuel_valve_block_out,t_inc,CORRECTOR);
+  double fuel_flow_block_out = fuel_flow_block.getoutput(fuel_valve_block_out,t_inc,CORRECTOR,true);
 
   Pmech = fuel_flow_block_out - Dt*delta_w;
 
   // Exhaust temperature block
-  exh_temp_block_out = exh_temp_block.getoutput(fuel_flow_block_out,t_inc,CORRECTOR);
+  exh_temp_block_out = exh_temp_block.getoutput(fuel_flow_block_out,t_inc,CORRECTOR,true);
 
 }
 

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.cpp
@@ -57,8 +57,8 @@ void gridpack::dynamic_simulation::GastModel::load(
   if (!data->getValue(GOVERNOR_T1, &T1, idx)) T1 = 0.5;
   if (!data->getValue(GOVERNOR_T2, &T2, idx)) T2 = 3.0; 
   if (!data->getValue(GOVERNOR_T3, &T3, idx)) T3 = 10.0;
-  if (!data->getValue(GOVERNOR_AT, &AT, idx)) KT = 0.0;
-  if (!data->getValue(GOVERNOR_KT, &KT, idx))  AT = 0.0;
+  if (!data->getValue(GOVERNOR_AT, &AT, idx)) AT = 0.0;
+  if (!data->getValue(GOVERNOR_KT, &KT, idx))  KT = 0.0;
   if (!data->getValue(GOVERNOR_VMAX, &VMAX, idx)) VMAX = 1.0; 
   if (!data->getValue(GOVERNOR_VMIN, &VMIN, idx)) VMIN = 0.0; 
   if (!data->getValue(GOVERNOR_DT, &Dt, idx)) Dt = 0.0;

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.cpp
@@ -1,0 +1,202 @@
+/*
+ *     Copyright (c) 2013 Battelle Memorial Institute
+ *     Licensed under modified BSD License. A copy of this license can be found
+ *     in the LICENSE file in the top level directory of this distribution.
+ */
+// -----------------------------------------------------------
+/**
+ * @file   gast.cpp
+ * @author Shrirang Abhyankar
+ * Added:  November 7, 2022
+ * 
+ * @brief  
+ * Gas turbine governor model
+ * 
+ */
+
+#include <vector>
+#include <iostream>
+#include <stdio.h>
+
+#include "boost/smart_ptr/shared_ptr.hpp"
+#include "gridpack/parser/dictionary.hpp"
+#include "base_governor_model.hpp"
+#include "gast.hpp"
+
+#define TS_THRESHOLD 4
+
+/**
+ *  Basic constructor
+ */
+gridpack::dynamic_simulation::GastModel::GastModel(void)
+{
+  Pmech = 1.0;
+  Pref = 1.0;
+  delta_w = 0.0;
+}
+
+/**
+ *  Basic destructor
+ */
+gridpack::dynamic_simulation::GastModel::~GastModel(void)
+{
+}
+
+/**
+ * Load parameters from DataCollection object into governor model
+ * @param data collection of governor parameters from input files
+ * @param index of governor on bus
+ * TODO: might want to move this functionality to
+ * GastModel
+ */
+void gridpack::dynamic_simulation::GastModel::load(
+    boost::shared_ptr<gridpack::component::DataCollection>
+    data, int idx)
+{
+  if (!data->getValue(GOVERNOR_R, &R, idx)) R = 0.05; 
+  if (!data->getValue(GOVERNOR_T1, &T1, idx)) T1 = 0.5;
+  if (!data->getValue(GOVERNOR_T2, &T2, idx)) T2 = 3.0; 
+  if (!data->getValue(GOVERNOR_T3, &T3, idx)) T3 = 10.0;
+  if (!data->getValue(GOVERNOR_AT, &AT, idx)) KT = 0.0;
+  if (!data->getValue(GOVERNOR_KT, &KT, idx))  AT = 0.0;
+  if (!data->getValue(GOVERNOR_VMAX, &VMAX, idx)) VMAX = 1.0; 
+  if (!data->getValue(GOVERNOR_VMIN, &VMIN, idx)) VMIN = 0.0; 
+  if (!data->getValue(GOVERNOR_DT, &Dt, idx)) Dt = 0.0;
+
+  fuel_valve_block.setparams(1.0,T1,VMIN,VMAX,-10000,10000);
+  fuel_flow_block.setparams(1.0,T2);
+  exh_temp_block.setparams(1.0,T3);
+}
+
+/**
+ * Initialize governor model before calculation
+ * @param mag voltage magnitude
+ * @param ang voltage angle
+ * @param ts time step 
+ */
+void gridpack::dynamic_simulation::GastModel::init(double mag, double ang, double ts)
+{
+  //  Work backwards from Pmech
+  double fuel_flow_block_out = Pmech + Dt*delta_w;
+  
+  double fuel_valve_block_out;
+
+  // Initialize fuel valve block
+  fuel_valve_block_out = fuel_flow_block.init_given_y(fuel_flow_block_out);
+
+  // Initialize exh_temp_block
+  exh_temp_block_out = exh_temp_block.init_given_u(fuel_flow_block_out);
+
+  // Initialize fuel_valve_block
+  double fuel_valve_block_in = fuel_valve_block.init_given_y(fuel_valve_block_out);
+  double droop = delta_w/R;
+
+  double lv_gate_in1 = AT + KT*(AT - exh_temp_block_out);
+
+  Pref = fuel_valve_block_in + delta_w*R; // Here the assumption is lv_gate_in1 > fuel_valve_block_in.
+  // If this condition is not satisfied then Pref value is indeterminate.
+}
+
+/**
+ * Predict new state variables for time step
+ * @param t_inc time step increment
+ * @param flag initial step if true
+ */
+void gridpack::dynamic_simulation::GastModel::predictor(double t_inc, bool flag)
+{
+  double droop = delta_w/R;
+
+  double lv_gate_in1 = AT + KT*(AT - exh_temp_block_out);
+
+  double fuel_valve_block_in = std::min(lv_gate_in1,Pref - droop);
+
+  // Fuel valve block
+  double fuel_valve_block_out = fuel_valve_block.getoutput(fuel_valve_block_in,t_inc,PREDICTOR);
+
+  // Fuel flow block
+  double fuel_flow_block_out = fuel_flow_block.getoutput(fuel_valve_block_out,t_inc,PREDICTOR);
+
+  Pmech = fuel_flow_block_out - Dt*delta_w;
+
+  // Exhaust temperature block
+  exh_temp_block_out = exh_temp_block.getoutput(fuel_flow_block_out,t_inc,PREDICTOR);
+  
+}
+
+/**
+ * Correct state variables for time step
+ * @param t_inc time step increment
+ * @param flag initial step if true
+ */
+void gridpack::dynamic_simulation::GastModel::corrector(double t_inc, bool flag)
+{
+  double droop = delta_w/R;
+
+  double lv_gate_in1 = AT + KT*(AT - exh_temp_block_out);
+
+  double fuel_valve_block_in = std::min(lv_gate_in1,Pref - droop);
+
+  // Fuel valve block
+  double fuel_valve_block_out = fuel_valve_block.getoutput(fuel_valve_block_in,t_inc,CORRECTOR);
+
+  // Fuel flow block
+  double fuel_flow_block_out = fuel_flow_block.getoutput(fuel_valve_block_out,t_inc,CORRECTOR);
+
+  Pmech = fuel_flow_block_out - Dt*delta_w;
+
+  // Exhaust temperature block
+  exh_temp_block_out = exh_temp_block.getoutput(fuel_flow_block_out,t_inc,CORRECTOR);
+
+}
+
+/**
+ * Set the mechanical power parameter inside the governor
+ * @param pmech value of the mechanical power
+ */
+void gridpack::dynamic_simulation::GastModel::setMechanicalPower(double pmech)
+{
+  Pmech = pmech; 
+}
+
+/**
+ * Set the rotor speed deviation inside the governor
+ * @param delta_o value of the rotor speed deviation
+ */
+void gridpack::dynamic_simulation::GastModel::setRotorSpeedDeviation(double delta_w)
+{
+  delta_w = delta_w;
+}
+
+/** 
+ * Get the value of the mechanical power
+ * @return value of mechanical power
+ */
+double gridpack::dynamic_simulation::GastModel::getMechanicalPower()
+{
+  return Pmech; 
+}
+
+/** 
+ * Get the value of the rotor speed deviation
+ * 
+ */
+
+/** 
+ * Set the governor generator bus number
+ */
+ /**
+void gridpack::dynamic_simulation::GastModel::setExtBusNum(int ExtBusNum)
+{
+	p_bus_id = ExtBusNum;
+}
+*/	
+
+/** 
+ * Set the governor generator id
+ */
+ /**
+void gridpack::dynamic_simulation::GastModel::setExtGenId(std::string ExtGenId)
+{
+	p_ckt = ExtGenId;
+}
+*/

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gast.hpp
@@ -1,0 +1,124 @@
+/*
+ *     Copyright (c) 2013 Battelle Memorial Institute
+ *     Licensed under modified BSD License. A copy of this license can be found
+ *     in the LICENSE file in the top level directory of this distribution.
+ */
+// -------------------------------------------------------------
+/**
+ * @file   gast.hpp
+ * @author Shrirang Abhyankar
+ * @Last modified:   November 7, 2022
+ * 
+ * @brief  
+ * Gas-Turbine governor model
+ * 
+ */
+
+#ifndef _gast_h_
+#define _gast_h_
+
+#include "boost/smart_ptr/shared_ptr.hpp"
+#include "base_governor_model.hpp"
+#include "cblock.hpp"
+
+namespace gridpack {
+namespace dynamic_simulation {
+class GastModel : public BaseGovernorModel
+{
+  public:
+    /**
+     * Basic constructor
+     */
+    GastModel();
+
+    /**
+     * Basic destructor
+     */
+    virtual ~GastModel();
+
+    /**
+     * Load parameters from DataCollection object into governor model
+     * @param data collection of governor parameters from input files
+     * @param index of governor on bus
+     * TODO: might want to move this functionality to BaseGovernorModel
+     */
+    void load(boost::shared_ptr<gridpack::component::DataCollection>
+        data, int idx);
+
+    /**
+     * Initialize governor model before calculation
+     * @param mag voltage magnitude
+     * @param ang voltage angle
+     * @param ts time step 
+     */
+    void init(double mag, double ang, double ts);
+
+    /**
+     * Predict new state variables for time step
+     * @param t_inc time step increment
+     * @param flag initial step if true
+     */
+    void predictor(double t_inc, bool flag);
+
+    /**
+     * Correct state variables for time step
+     * @param t_inc time step increment
+     * @param flag initial step if true
+     */
+    void corrector(double t_inc, bool flag);
+
+    /**
+     * Set the mechanical power parameter inside the governor
+     * @param pmech value of the mechanical power
+     */
+    void setMechanicalPower(double pmech);
+
+    /**
+     * Set the rotor speed deviation inside the governor
+     * @param delta_o value of the rotor speed deviation
+     */
+    void setRotorSpeedDeviation(double delta_w);
+
+    /** 
+     * Get the value of the mechanical power
+     * @return value of mechanical power
+     */
+    double getMechanicalPower();
+
+    /** 
+     * Set the governor bus number
+     */
+    //void setExtBusNum(int ExtBusNum);
+	
+    /** 
+     * Set the governor generator id
+     */
+    //void setExtGenId(std::string ExtGenId);
+
+  private:
+
+    // Governor Gast Parameters read from dyr
+    double R, T1, T2, T3, AT, KT, Dt, VMAX, VMIN;
+
+    // Gast control blocks
+    Filter fuel_valve_block;
+    Filter fuel_flow_block;
+    Filter exh_temp_block;
+
+    // Outputs: Mechnical Power
+    double Pmech;
+
+    // The exhaust block forms a feedback system that is hard
+    // to resolve. We hold the value of exhaust block output
+    // and use it in the calculation with one step delay in the
+    // feedback loop
+    double exh_temp_block_out;
+
+    // Inputs
+    double Pref;   // Load reference
+    double delta_w;  // speed deviation
+
+};
+}  // dynamic_simulation
+}  // gridpack
+#endif

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.cpp
@@ -693,26 +693,55 @@ void gridpack::dynamic_simulation::GenrouGenerator::write(
 bool gridpack::dynamic_simulation::GenrouGenerator::serialWrite(
     char* string, const int bufsize, const char *signal)
 {
+  bool ret = false;
   if (!strcmp(signal,"standard")) {
     sprintf(string,"      %8d            %2s    %12.6f    %12.6f    %12.6f    %12.6f	%12.6f  %12.6f\n",
           p_bus_id, p_ckt.c_str(), x1d_1, x2w_1+1.0, x3Eqp_1, x4Psidp_1, x5Psiqp_1, x6Edp_1);
-    return true;
+    ret = true;
   } else if (!strcmp(signal,"init_debug")) {
     sprintf(string," %8d  %2s Something\n",p_bus_id,p_ckt.c_str());
-    return true;
+    ret = true;
   } else if (!strcmp(signal,"debug_initial")) {
     sprintf(string,"Bus: %d PG: %f QG: %f\n",p_bus_id,p_pg,p_qg);
-    return true;
+    ret = true;
+  } else if(!strcmp(signal,"watch_header")) {
+    if(getWatch()) {
+      char buf[128];
+      std::string tag;
+      if(p_ckt[0] != ' ') {
+	tag = p_ckt;
+      } else {
+	tag = p_ckt[1];
+      }
+      sprintf(buf,", %d_%s_angle, %d_%s_speed",p_bus_id,tag.c_str(),
+          p_bus_id,tag.c_str());
+      if (strlen(buf) <= bufsize) {
+        sprintf(string,"%s",buf);
+        ret = true;
+      } else {
+        ret = false;
+      }
+    } else {
+      ret = false;
+    }
   } else if (!strcmp(signal,"watch")) {
     if (getWatch()) {
-      char buf[128];
-      sprintf(string,",%8d, %2s, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f, %12.6f,",
-          p_bus_id, p_ckt.c_str(), x1d_1, x2w_1+1.0, x3Eqp_1, x4Psidp_1, x5Psiqp_1, x6Edp_1, Vterm, Efd, LadIfd);
-      return true;
+      char buf[256];
+      sprintf(buf,",%f, %f",
+	      x1d_1, x2w_1+1.0);
+      if (strlen(buf) <= bufsize) {
+        sprintf(string,"%s",buf);
+        ret = true;
+      } else {
+        ret = false;
+      }
+    } else {
+      ret = false;
     }
   } else if (!strcmp(signal,"debug_initial")) {
-  return false;
+    ret = false;
   }
+  return ret;
 } 
 
 /**

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/hygov.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/hygov.cpp
@@ -107,11 +107,11 @@ void gridpack::dynamic_simulation::HygovModel::predictor(double t_inc, bool flag
 {
   filter_block_in = nref - (delta_w + R*gate_block_out);
 
-  double filter_block_out = filter_block.getoutput(filter_block_in,t_inc,PREDICTOR);
+  double filter_block_out = filter_block.getoutput(filter_block_in,t_inc,PREDICTOR,true);
 
-  gate_block_out = gate_block.getoutput(filter_block_out,t_inc,PREDICTOR);
+  gate_block_out = gate_block.getoutput(filter_block_out,t_inc,PREDICTOR,true);
 
-  opening_block_out = opening_block.getoutput(gate_block_out,t_inc,PREDICTOR);
+  opening_block_out = opening_block.getoutput(gate_block_out,t_inc,PREDICTOR,true);
 
   double turbine_flow_block_in,h;
 
@@ -120,7 +120,7 @@ void gridpack::dynamic_simulation::HygovModel::predictor(double t_inc, bool flag
 
   turbine_flow_block_in = 1 - h;
 
-  turbine_flow_block_out = turbine_flow_block.getoutput(turbine_flow_block_in,t_inc,PREDICTOR);
+  turbine_flow_block_out = turbine_flow_block.getoutput(turbine_flow_block_in,t_inc,PREDICTOR,true);
 
   Pmech =  AT*(turbine_flow_block_out - qNL)*h - opening_block_out*Dt*delta_w;
 }
@@ -134,11 +134,11 @@ void gridpack::dynamic_simulation::HygovModel::corrector(double t_inc, bool flag
 {
   filter_block_in = nref - (delta_w + R*gate_block_out);
 
-  double filter_block_out = filter_block.getoutput(filter_block_in,t_inc,CORRECTOR);
+  double filter_block_out = filter_block.getoutput(filter_block_in,t_inc,CORRECTOR,true);
 
-  gate_block_out = gate_block.getoutput(filter_block_out,t_inc,CORRECTOR);
+  gate_block_out = gate_block.getoutput(filter_block_out,t_inc,CORRECTOR,true);
 
-  opening_block_out = opening_block.getoutput(gate_block_out,t_inc,CORRECTOR);
+  opening_block_out = opening_block.getoutput(gate_block_out,t_inc,CORRECTOR,true);
 
   double turbine_flow_block_in,h;
 
@@ -147,7 +147,7 @@ void gridpack::dynamic_simulation::HygovModel::corrector(double t_inc, bool flag
 
   turbine_flow_block_in = 1 - h;
 
-  turbine_flow_block_out = turbine_flow_block.getoutput(turbine_flow_block_in,t_inc,CORRECTOR);
+  turbine_flow_block_out = turbine_flow_block.getoutput(turbine_flow_block_in,t_inc,CORRECTOR,true);
 
   Pmech =  AT*(turbine_flow_block_out - qNL)*h - opening_block_out*Dt*delta_w;
 

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/hygov.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/hygov.cpp
@@ -1,0 +1,206 @@
+/*
+ *     Copyright (c) 2013 Battelle Memorial Institute
+ *     Licensed under modified BSD License. A copy of this license can be found
+ *     in the LICENSE file in the top level directory of this distribution.
+ */
+// -----------------------------------------------------------
+/**
+ * @file   hygov.cpp
+ * @author Shrirang Abhyankar
+ * Added:  November 7, 2022
+ * 
+ * @brief  
+ * Hydro turbine governor model
+ * 
+ */
+
+#include <vector>
+#include <iostream>
+#include <stdio.h>
+
+#include "boost/smart_ptr/shared_ptr.hpp"
+#include "gridpack/parser/dictionary.hpp"
+#include "base_governor_model.hpp"
+#include "hygov.hpp"
+
+#define TS_THRESHOLD 4
+
+/**
+ *  Basic constructor
+ */
+gridpack::dynamic_simulation::HygovModel::HygovModel(void)
+{
+  Pmech = 1.0;
+  nref = 1.0;
+  delta_w = 0.0;
+}
+
+/**
+ *  Basic destructor
+ */
+gridpack::dynamic_simulation::HygovModel::~HygovModel(void)
+{
+}
+
+/**
+ * Load parameters from DataCollection object into governor model
+ * @param data collection of governor parameters from input files
+ * @param index of governor on bus
+ * TODO: might want to move this functionality to
+ * HygovModel
+ */
+void gridpack::dynamic_simulation::HygovModel::load(
+    boost::shared_ptr<gridpack::component::DataCollection>
+    data, int idx)
+{
+  if (!data->getValue(GOVERNOR_R, &R, idx)) R = 0.05;
+  if (!data->getValue(GOVERNOR_r, &r, idx)) R = 0.05; 
+  if (!data->getValue(GOVERNOR_TR, &TR, idx)) TR = 0.5;
+  if (!data->getValue(GOVERNOR_TF, &TF, idx)) TF = 3.0; 
+  if (!data->getValue(GOVERNOR_TG, &TG, idx)) TG = 10.0;
+  if (!data->getValue(GOVERNOR_VELM, &VELM, idx)) VELM = 1000.0;
+  if (!data->getValue(GOVERNOR_GMAX, &GMAX, idx)) GMAX = 1.0; 
+  if (!data->getValue(GOVERNOR_GMIN, &GMIN, idx)) GMIN = 0.0; 
+  if (!data->getValue(GOVERNOR_TW, &TW, idx)) TW = 10.0;
+  if (!data->getValue(GOVERNOR_AT, &AT, idx)) AT = 1.0;
+  if (!data->getValue(GOVERNOR_DT, &Dt, idx)) Dt = 0.0;
+  if (!data->getValue(GOVERNOR_QNL, &qNL, idx))  qNL = 0.0;
+
+  filter_block.setparams(1.0,TF);
+  gate_block.setparams(1/r,1/(r*TR),GMIN,GMAX,-10000,10000);
+  opening_block.setparams(1.0,TG);
+  turbine_flow_block.setparams(TW);
+}
+
+/**
+ * Initialize governor model before calculation
+ * @param mag voltage magnitude
+ * @param ang voltage angle
+ * @param ts time step 
+ */
+void gridpack::dynamic_simulation::HygovModel::init(double mag, double ang, double ts)
+{
+  turbine_flow_block_out = Pmech/AT + qNL;
+
+  double turbine_flow_block_in;
+
+  turbine_flow_block_in = turbine_flow_block.init_given_y(turbine_flow_block_out);
+
+  opening_block_out = turbine_flow_block_out;
+
+  gate_block_out = opening_block.init_given_y(opening_block_out);
+
+  double gate_block_in;
+  gate_block_in = gate_block.init_given_y(gate_block_out);
+  
+  filter_block_in = filter_block.init_given_y(gate_block_in);
+
+  nref = filter_block_in + R*gate_block_out + delta_w;
+}
+
+/**
+ * Predict new state variables for time step
+ * @param t_inc time step increment
+ * @param flag initial step if true
+ */
+void gridpack::dynamic_simulation::HygovModel::predictor(double t_inc, bool flag)
+{
+  filter_block_in = nref - (delta_w + R*gate_block_out);
+
+  double filter_block_out = filter_block.getoutput(filter_block_in,t_inc,PREDICTOR);
+
+  gate_block_out = gate_block.getoutput(filter_block_out,t_inc,PREDICTOR);
+
+  opening_block_out = opening_block.getoutput(gate_block_out,t_inc,PREDICTOR);
+
+  double turbine_flow_block_in,h;
+
+  h = opening_block_out/turbine_flow_block_out;
+  h = h*h;
+
+  turbine_flow_block_in = 1 - h;
+
+  turbine_flow_block_out = turbine_flow_block.getoutput(turbine_flow_block_in,t_inc,PREDICTOR);
+
+  Pmech =  AT*(turbine_flow_block_out - qNL)*h - opening_block_out*Dt*delta_w;
+}
+
+/**
+ * Correct state variables for time step
+ * @param t_inc time step increment
+ * @param flag initial step if true
+ */
+void gridpack::dynamic_simulation::HygovModel::corrector(double t_inc, bool flag)
+{
+  filter_block_in = nref - (delta_w + R*gate_block_out);
+
+  double filter_block_out = filter_block.getoutput(filter_block_in,t_inc,CORRECTOR);
+
+  gate_block_out = gate_block.getoutput(filter_block_out,t_inc,CORRECTOR);
+
+  opening_block_out = opening_block.getoutput(gate_block_out,t_inc,CORRECTOR);
+
+  double turbine_flow_block_in,h;
+
+  h = opening_block_out/turbine_flow_block_out;
+  h = h*h;
+
+  turbine_flow_block_in = 1 - h;
+
+  turbine_flow_block_out = turbine_flow_block.getoutput(turbine_flow_block_in,t_inc,CORRECTOR);
+
+  Pmech =  AT*(turbine_flow_block_out - qNL)*h - opening_block_out*Dt*delta_w;
+
+}
+
+/**
+ * Set the mechanical power parameter inside the governor
+ * @param pmech value of the mechanical power
+ */
+void gridpack::dynamic_simulation::HygovModel::setMechanicalPower(double pmech)
+{
+  Pmech = pmech; 
+}
+
+/**
+ * Set the rotor speed deviation inside the governor
+ * @param delta_o value of the rotor speed deviation
+ */
+void gridpack::dynamic_simulation::HygovModel::setRotorSpeedDeviation(double delta_w)
+{
+  delta_w = delta_w;
+}
+
+/** 
+ * Get the value of the mechanical power
+ * @return value of mechanical power
+ */
+double gridpack::dynamic_simulation::HygovModel::getMechanicalPower()
+{
+  return Pmech; 
+}
+
+/** 
+ * Get the value of the rotor speed deviation
+ * 
+ */
+
+/** 
+ * Set the governor generator bus number
+ */
+ /**
+void gridpack::dynamic_simulation::HygovModel::setExtBusNum(int ExtBusNum)
+{
+	p_bus_id = ExtBusNum;
+}
+*/	
+
+/** 
+ * Set the governor generator id
+ */
+ /**
+void gridpack::dynamic_simulation::HygovModel::setExtGenId(std::string ExtGenId)
+{
+	p_ckt = ExtGenId;
+}
+*/

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/hygov.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/hygov.hpp
@@ -1,0 +1,120 @@
+/*
+ *     Copyright (c) 2013 Battelle Memorial Institute
+ *     Licensed under modified BSD License. A copy of this license can be found
+ *     in the LICENSE file in the top level directory of this distribution.
+ */
+// -------------------------------------------------------------
+/**
+ * @file   hygov.hpp
+ * @author Shrirang Abhyankar
+ * @Created:   November 7, 2022
+ * 
+ * @brief  
+ * Hydro turbine governor model
+ * 
+ */
+
+#ifndef _hygov_h_
+#define _hygov_h_
+
+#include "boost/smart_ptr/shared_ptr.hpp"
+#include "base_governor_model.hpp"
+#include "cblock.hpp"
+
+namespace gridpack {
+namespace dynamic_simulation {
+class HygovModel : public BaseGovernorModel
+{
+  public:
+    /**
+     * Basic constructor
+     */
+    HygovModel();
+
+    /**
+     * Basic destructor
+     */
+    virtual ~HygovModel();
+
+    /**
+     * Load parameters from DataCollection object into governor model
+     * @param data collection of governor parameters from input files
+     * @param index of governor on bus
+     * TODO: might want to move this functionality to BaseGovernorModel
+     */
+    void load(boost::shared_ptr<gridpack::component::DataCollection>
+        data, int idx);
+
+    /**
+     * Initialize governor model before calculation
+     * @param mag voltage magnitude
+     * @param ang voltage angle
+     * @param ts time step 
+     */
+    void init(double mag, double ang, double ts);
+
+    /**
+     * Predict new state variables for time step
+     * @param t_inc time step increment
+     * @param flag initial step if true
+     */
+    void predictor(double t_inc, bool flag);
+
+    /**
+     * Correct state variables for time step
+     * @param t_inc time step increment
+     * @param flag initial step if true
+     */
+    void corrector(double t_inc, bool flag);
+
+    /**
+     * Set the mechanical power parameter inside the governor
+     * @param pmech value of the mechanical power
+     */
+    void setMechanicalPower(double pmech);
+
+    /**
+     * Set the rotor speed deviation inside the governor
+     * @param delta_o value of the rotor speed deviation
+     */
+    void setRotorSpeedDeviation(double delta_w);
+
+    /** 
+     * Get the value of the mechanical power
+     * @return value of mechanical power
+     */
+    double getMechanicalPower();
+
+    /** 
+     * Set the governor bus number
+     */
+    //void setExtBusNum(int ExtBusNum);
+	
+    /** 
+     * Set the governor generator id
+     */
+    //void setExtGenId(std::string ExtGenId);
+
+  private:
+
+    // Governor Hygov Parameters read from dyr
+    double R, r, TR, TF, TG, VELM, GMAX, GMIN, TW,AT, Dt, qNL;
+
+    // Hygov control blocks
+    Filter    filter_block; // output e
+    PIControl gate_block; // output c
+    Filter    opening_block; // output g
+    Integrator turbine_flow_block; // output q
+
+    double opening_block_out, gate_block_out,turbine_flow_block_out,filter_block_in;
+    // Outputs: Mechnical Power
+    double Pmech;
+
+    // Inputs
+    double nref;     // reference
+    double delta_w;  // speed deviation
+
+};
+}  // dynamic_simulation
+}  // gridpack
+#endif

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.cpp
@@ -110,9 +110,9 @@ void gridpack::dynamic_simulation::SexsModel::predictor(double t_inc, bool flag)
 
   u1 = Vref - Vterminal;
   
-  y1 = leadlagblock.getoutput(u1,t_inc,PREDICTOR);
+  y1 = leadlagblock.getoutput(u1,t_inc,PREDICTOR,true);
 
-  Efd = filterblock.getoutput(y1,t_inc,PREDICTOR);
+  Efd = filterblock.getoutput(y1,t_inc,PREDICTOR,true);
 }
 
 /**
@@ -126,9 +126,9 @@ void gridpack::dynamic_simulation::SexsModel::corrector(double t_inc, bool flag)
 
   u1 = Vref - Vterminal;
   
-  y1 = leadlagblock.getoutput(u1,t_inc,CORRECTOR);
+  y1 = leadlagblock.getoutput(u1,t_inc,CORRECTOR,true);
 
-  Efd = filterblock.getoutput(y1,t_inc,CORRECTOR);
+  Efd = filterblock.getoutput(y1,t_inc,CORRECTOR,true);
 }
 
 /**

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.cpp
@@ -5,9 +5,9 @@
  */
 // -----------------------------------------------------------
 /**
- * @file   exdc1.cpp
+ * @file   sexs.cpp
  * @author Shrirang Abhyankar
- * @Last modified:   Nov 6, 2022
+ * @Added:   Nov 6, 2022
  * 
  * @brief  
  * 

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.cpp
@@ -1,0 +1,212 @@
+/*
+ *     Copyright (c) 2013 Battelle Memorial Institute
+ *     Licensed under modified BSD License. A copy of this license can be found
+ *     in the LICENSE file in the top level directory of this distribution.
+ */
+// -----------------------------------------------------------
+/**
+ * @file   exdc1.cpp
+ * @author Shrirang Abhyankar
+ * @Last modified:   Nov 6, 2022
+ * 
+ * @brief  
+ * 
+ * 
+ */
+
+#include <vector>
+#include <iostream>
+#include <cstdio>
+
+// Yuan added below 2020-6-23
+//#include <cstdio>
+#include <cstring>
+#include <string>
+// Yuan added above 2020-6-23
+
+#include "boost/smart_ptr/shared_ptr.hpp"
+#include "gridpack/parser/dictionary.hpp"
+#include "base_exciter_model.hpp"
+#include "sexs.hpp"
+
+#define TS_THRESHOLD 4
+
+/**
+ *  Basic constructor
+ */
+gridpack::dynamic_simulation::SexsModel::SexsModel(void)
+{
+  OptionToModifyLimitsForInitialStateLimitViolation = true;
+}
+
+/**
+ *  Basic destructor
+ */
+gridpack::dynamic_simulation::SexsModel::~SexsModel(void)
+{
+}
+
+/**
+ * Load parameters from DataCollection object into exciter model
+ * @param data collection of exciter parameters from input files
+ * @param index of exciter on bus
+ * TODO: might want to move this functionality to
+ * SexsModel
+ */
+void gridpack::dynamic_simulation::SexsModel::load(
+    boost::shared_ptr<gridpack::component::DataCollection>
+    data, int idx)
+{
+  if (!data->getValue(EXCITER_TA_OVER_TB, &TA_OVER_TB, idx)) TA_OVER_TB = 0.0; // TA_OVER_TB
+  if (!data->getValue(EXCITER_TB, &TB, idx)) TB = 0.0; // TB
+  if (!data->getValue(EXCITER_K, &K, idx))   K  = 0.0; // K
+  if (!data->getValue(EXCITER_EMAX, &EMAX, idx)) EMAX = 0.0; // EMAX
+  if (!data->getValue(EXCITER_EMIN, &EMIN, idx)) EMIN = 0.0; // EMIN
+  if (!data->getValue(EXCITER_TE, &TE, idx)) TE = 0.0; // TE
+
+  TA = TA_OVER_TB*TB;
+
+  leadlagblock.setparams(TA,TB);
+  filterblock.setparams(K,TE,EMIN,EMAX,-1000.0,1000);
+}
+
+/**
+ *  * Saturation function
+ *   * @ param x
+ *    */
+double gridpack::dynamic_simulation::SexsModel::Sat(double x)
+{
+	return 0;
+}
+
+/**
+ * Initialize exciter model before calculation
+ * @param mag voltage magnitude
+ * @param ang voltage angle
+ * @param ts time step 
+ */
+void gridpack::dynamic_simulation::SexsModel::init(double mag, double ang, double ts)
+{
+  filterblock.init(0.0,Efd); // Initialize second integrator
+  double y1 = Efd/K;         // Output of first block
+
+  leadlagblock.init(0.0,y1); // Initialize first integrator
+  double u1 = y1/(1 - TA + TA_OVER_TB); // Input for first integrator
+
+  Vstab = 0.0; // No stabilizer signal implemented
+  
+  Vref = mag + u1;   // Voltage reference
+
+}
+
+/**
+ * Predict new state variables for time step
+ * @param t_inc time step increment
+ * @param flag initial step if true
+ */
+void gridpack::dynamic_simulation::SexsModel::predictor(double t_inc, bool flag)
+{
+  double u1,y1;
+
+  u1 = Vref - Vterminal;
+  
+  y1 = leadlagblock.getoutput(u1,t_inc,PREDICTOR);
+
+  Efd = filterblock.getoutput(y1,t_inc,PREDICTOR);
+}
+
+/**
+ * Correct state variables for time step
+ * @param t_inc time step increment
+ * @param flag initial step if true
+ */
+void gridpack::dynamic_simulation::SexsModel::corrector(double t_inc, bool flag)
+{
+  double u1,y1;
+
+  u1 = Vref - Vterminal;
+  
+  y1 = leadlagblock.getoutput(u1,t_inc,CORRECTOR);
+
+  Efd = filterblock.getoutput(y1,t_inc,CORRECTOR);
+}
+
+/**
+ * Set the field voltage parameter inside the exciter
+ * @param fldv value of the field voltage
+ */
+void gridpack::dynamic_simulation::SexsModel::setFieldVoltage(double fldv)
+{
+  Efd = fldv;
+}
+
+/**
+ * Set the field current parameter inside the exciter
+ * @param fldc value of the field current
+ */
+void gridpack::dynamic_simulation::SexsModel::setFieldCurrent(double fldc)
+{
+  LadIfd = fldc;
+}
+
+/** 
+ * Get the value of the field voltage parameter
+ * @return value of field voltage
+ */
+double gridpack::dynamic_simulation::SexsModel::getFieldVoltage()
+{
+  return Efd;
+}
+
+/** 
+ * Get the value of the field current parameter
+ * @return value of field current
+ */
+double gridpack::dynamic_simulation::SexsModel::getFieldCurrent()
+{
+  return 0.0;
+}
+
+/** 
+ * Set the value of the Vterminal
+ * @return value of field current
+ */
+void gridpack::dynamic_simulation::SexsModel::setVterminal(double mag)
+{
+  Vterminal = mag;
+}
+
+/** 
+ * Set the value of the omega
+ * @return value of field current
+ */
+void gridpack::dynamic_simulation::SexsModel::setOmega(double omega)
+{
+}
+
+void gridpack::dynamic_simulation::SexsModel::setVstab(double vtmp)
+{
+  Vstab = vtmp;
+}
+
+
+// Yuan added below 2020-6-23
+/** 
+ * Set the exciter bus number
+ * @return value of exciter bus number
+ */
+void gridpack::dynamic_simulation::SexsModel::setExtBusNum(int ExtBusNum)
+{
+	p_bus_id = ExtBusNum;
+}	
+
+/** 
+ * Set the exciter generator id
+ * @return value of generator id
+ */
+void gridpack::dynamic_simulation::SexsModel::setExtGenId(std::string ExtGenId)
+{
+	p_ckt = ExtGenId;
+}	
+// Yuan added above 2020-6-23
+

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/sexs.hpp
@@ -1,0 +1,162 @@
+/*
+ *     Copyright (c) 2013 Battelle Memorial Institute
+ *     Licensed under modified BSD License. A copy of this license can be found
+ *     in the LICENSE file in the top level directory of this distribution.
+ */
+// -------------------------------------------------------------
+/**
+ * @file   sexs.hpp
+ * @author Shrirang Abhyankar
+ * @Last modified:   Nov 6, 2022
+ * 
+ * @brief  
+ * 
+ * 
+ */
+
+#ifndef _sexs_h_
+#define _sexs_h_
+
+#include "boost/smart_ptr/shared_ptr.hpp"
+#include "base_exciter_model.hpp"
+// Yuan added below 2020-6-23
+#include <string>
+// Yuan added above 2020-6-23
+
+#include "cblock.hpp"
+
+namespace gridpack {
+namespace dynamic_simulation {
+class SexsModel : public BaseExciterModel
+{
+  public:
+    /**
+     * Basic constructor
+     */
+    SexsModel();
+
+    /**
+     * Basic destructor
+     */
+    virtual ~SexsModel();
+
+    /**
+     * Load parameters from DataCollection object into exciter model
+     * @param data collection of exciter parameters from input files
+     * @param index of exciter on bus
+     * TODO: might want to move this functionality to BaseExciterModel
+     */
+    void load(boost::shared_ptr<gridpack::component::DataCollection>
+        data, int idx);
+
+    /**
+     * Saturation function
+     * @ param x
+     */
+    double Sat(double x);
+
+    /**
+     * Initialize exciter model before calculation
+     * @param mag voltage magnitude
+     * @param ang voltage angle
+     * @param ts time step 
+     */
+    void init(double mag, double ang, double ts);
+
+    /**
+     * Predict new state variables for time step
+     * @param t_inc time step increment
+     * @param flag initial step if true
+     */
+    void predictor(double t_inc, bool flag);
+
+    /**
+     * Correct state variables for time step
+     * @param t_inc time step increment
+     * @param flag initial step if true
+     */
+    void corrector(double t_inc, bool flag);
+
+    /**
+     * Set the field voltage parameter inside the exciter
+     * @param fldv value of the field voltage
+     */
+    void setFieldVoltage(double fldv);
+
+    /**
+     * Set the field current parameter inside the exciter
+     * @param fldc value of the field current
+     */
+    void setFieldCurrent(double fldc);
+
+    /** 
+     * Get the value of the field voltage parameter
+     * @return value of field voltage
+     */
+    double getFieldVoltage();
+
+    /** 
+     * Get the value of the field current parameter
+     * @return value of field current
+     */
+    double getFieldCurrent();
+
+    /** 
+     * Set the value of the Vterminal
+     * @return value of field current
+     */
+    void setVterminal(double mag);
+
+    /** 
+     * Set the value of the Omega 
+     * @return value of field current
+     */
+    void setOmega(double omega);
+	
+    void setVstab(double vstab);
+	
+	// Yuan added below 2020-6-23
+	/** 
+	 * Set the exciter bus number
+	 * @return value of exciter bus number
+	 */
+	void setExtBusNum(int ExtBusNum);
+	
+	/** 
+	 * Set the exciter generator id
+	 * @return value of generator id
+	 */
+	void setExtGenId(std::string ExtGenId);
+	// Yuan added above 2020-6-23
+
+  private:
+
+    bool OptionToModifyLimitsForInitialStateLimitViolation;
+
+    // Exciter SEXS parameters from dyr
+    double TA_OVER_TB, TA, TB, K, TE, EMIN, EMAX;
+
+    // Linear control blocks
+    LeadLag leadlagblock;
+    Filter  filterblock;
+  
+    // Field Voltage Output
+    double Efd;
+
+    // Field Current Output
+    double LadIfd, Vstab;
+
+    double Vref;
+
+    double Vterminal, w; 
+	
+	// Yuan added below 2020-6-23
+	std::string p_ckt; // id of the generator where the exciter is installed on
+    int p_bus_id;  // bus number of the generator 
+	// Yuan added above 2020-6-23
+
+    //boost::shared_ptr<BaseGeneratorModel> p_generator;
+};
+}  // dynamic_simulation
+}  // gridpack
+#endif

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -134,5 +134,6 @@ install(FILES
   parser_classes/ieelbl.hpp
   parser_classes/cmldblu1.hpp
   parser_classes/psssim.hpp
+  parser_classes/sexs.hpp
   DESTINATION include/gridpack/parser/parser_classes
 )

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -135,5 +135,6 @@ install(FILES
   parser_classes/cmldblu1.hpp
   parser_classes/psssim.hpp
   parser_classes/sexs.hpp
+  parser_classes/gast.hpp
   DESTINATION include/gridpack/parser/parser_classes
 )

--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -6,6 +6,9 @@
 /*
  *  Created on: December 30, 2014
  *      Author: Kevin Glass, Bruce Palmer
+ *
+ *  Added SEXS exciter model: Nov 7, 2022
+ *      Author: Shrirang Abhyankar
  */
 
 #ifndef BASEPTIPARSER_HPP_
@@ -54,6 +57,7 @@
 #include "parser_classes/ieelbl.hpp"
 #include "parser_classes/cmldblu1.hpp"
 #include "parser_classes/psssim.hpp"
+#include "parser_classes/sexs.hpp"
 
 namespace gridpack {
 namespace parser {
@@ -426,10 +430,14 @@ class BasePTIParser : public BaseParser<_network>
       // Exciter parameters
       bool has_exciter;
       double ex_tr;
+      double ex_k;
       double ex_ka;
+      double ex_ta_over_tb;
       double ex_ta;
       double ex_tb;
       double ex_tc;
+      double ex_emin;
+      double ex_emax;
       double vrmax;
       double vrmin;
       double ex_ke;
@@ -1021,6 +1029,9 @@ class BasePTIParser : public BaseParser<_network>
           } else if (!strcmp(gen_data[i].model,"ESST4B")) {
             Esst4bParser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);
+	  } else if (!strcmp(gen_data[i].model,"SEXS")) {
+            SexsParser<gen_params> parser;
+            parser.extract(gen_data[i], data, g_id);
           } else if (!strcmp(gen_data[i].model,"GGOV1")) {
             Ggov1Parser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);
@@ -1322,6 +1333,7 @@ class BasePTIParser : public BaseParser<_network>
           device == "GDFORM" ||
           device == "REGCA1" || device == "REECA1"  || device == "REPCA1" ||
           device == "WSIEG1" || device == "EXDC1" || device == "EXDC2" ||
+	  device == "SEXS"   ||
           device == "ESST1A" || device == "ESST4B" || device == "GGOV1" ||
           device == "WSHYGP" || device == "TGOV1" || device == "PSSSIM") {
         ret = true;
@@ -1483,6 +1495,9 @@ class BasePTIParser : public BaseParser<_network>
               parser.parse(split_line, data, g_id);
             } else if (sval == "EXDC1" || sval == "EXDC2") {
               Exdc1Parser<gen_params> parser;
+              parser.parse(split_line, data, g_id);
+	    } else if (sval == "SEXS") {
+              SexsParser<gen_params> parser;
               parser.parse(split_line, data, g_id);
             } else if (sval == "ESST1A") {
               Esst1aParser<gen_params> parser;
@@ -1677,6 +1692,9 @@ class BasePTIParser : public BaseParser<_network>
             parser.store(split_line,data);
           } else if (sval == "EXDC1" || sval == "EXDC2") {
             Exdc1Parser<gen_params> parser;
+            parser.store(split_line,data);
+	  } else if (sval == "SEXS") {
+            SexsParser<gen_params> parser;
             parser.store(split_line,data);
           } else if (sval == "ESST1A") {
             Esst1aParser<gen_params> parser;

--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -58,6 +58,7 @@
 #include "parser_classes/cmldblu1.hpp"
 #include "parser_classes/psssim.hpp"
 #include "parser_classes/sexs.hpp"
+#include "parser_classes/gast.hpp"
 
 namespace gridpack {
 namespace parser {
@@ -532,6 +533,8 @@ class BasePTIParser : public BaseParser<_network>
       int jbus;
       int gv_m;
       double gv_k;
+      double gv_kt;
+      double gv_at;
       double gv_t1;
       double gv_t2;
       double gv_t3;
@@ -1038,6 +1041,9 @@ class BasePTIParser : public BaseParser<_network>
           } else if (!strcmp(gen_data[i].model,"TGOV1")) {
             Tgov1Parser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);
+	  } else if (!strcmp(gen_data[i].model,"GAST")) {
+            GastParser<gen_params> parser;
+            parser.extract(gen_data[i], data, g_id);
           } else if (!strcmp(gen_data[i].model,"WSHYGP")) {
             WshygpParser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);
@@ -1332,8 +1338,8 @@ class BasePTIParser : public BaseParser<_network>
       if (device == "GENCLS" || device == "GENSAL" || device == "GENROU" ||
           device == "GDFORM" ||
           device == "REGCA1" || device == "REECA1"  || device == "REPCA1" ||
-          device == "WSIEG1" || device == "EXDC1" || device == "EXDC2" ||
-	  device == "SEXS"   ||
+          device == "WSIEG1" || device == "EXDC1"   || device == "EXDC2" ||
+	  device == "SEXS"   || device == "GAST"    ||
           device == "ESST1A" || device == "ESST4B" || device == "GGOV1" ||
           device == "WSHYGP" || device == "TGOV1" || device == "PSSSIM") {
         ret = true;
@@ -1510,6 +1516,9 @@ class BasePTIParser : public BaseParser<_network>
               parser.parse(split_line, data, g_id);
             } else if (sval == "TGOV1") {
               Tgov1Parser<gen_params> parser;
+              parser.parse(split_line, data, g_id);
+	    } else if (sval == "GAST") {
+              GastParser<gen_params> parser;
               parser.parse(split_line, data, g_id);
             } else if (sval == "WSHYGP") {
               WshygpParser<gen_params> parser;
@@ -1707,6 +1716,9 @@ class BasePTIParser : public BaseParser<_network>
             parser.store(split_line,data);
           } else if (sval == "TGOV1") {
             Tgov1Parser<gen_params> parser;
+            parser.store(split_line,data);
+	  } else if (sval == "GAST") {
+            GastParser<gen_params> parser;
             parser.store(split_line,data);
           } else if (sval == "WSHYGP") {
             WshygpParser<gen_params> parser;

--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -59,6 +59,7 @@
 #include "parser_classes/psssim.hpp"
 #include "parser_classes/sexs.hpp"
 #include "parser_classes/gast.hpp"
+#include "parser_classes/hygov.hpp"
 
 namespace gridpack {
 namespace parser {
@@ -571,6 +572,15 @@ class BasePTIParser : public BaseParser<_network>
       double rselect;
       double flagswitch;
       double gv_r;
+      double gv_r2;
+      double gv_tr;
+      double gv_tf;
+      double gv_tg;
+      double gv_velm;
+      double gv_gmax;
+      double gv_gmin;
+      double gv_tw;
+      double gv_qnl;
       double tpelec;
       double maxerr;
       double minerr;
@@ -606,7 +616,6 @@ class BasePTIParser : public BaseParser<_network>
       double rdown;
       double gv_td;
       double gv_ki;
-      double gv_tf;
       double gv_kd;
       double gv_kp;
       double gv_tt;
@@ -1044,6 +1053,9 @@ class BasePTIParser : public BaseParser<_network>
 	  } else if (!strcmp(gen_data[i].model,"GAST")) {
             GastParser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);
+	  } else if (!strcmp(gen_data[i].model,"HYGOV")) {
+            HygovParser<gen_params> parser;
+            parser.extract(gen_data[i], data, g_id);
           } else if (!strcmp(gen_data[i].model,"WSHYGP")) {
             WshygpParser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);
@@ -1339,7 +1351,7 @@ class BasePTIParser : public BaseParser<_network>
           device == "GDFORM" ||
           device == "REGCA1" || device == "REECA1"  || device == "REPCA1" ||
           device == "WSIEG1" || device == "EXDC1"   || device == "EXDC2" ||
-	  device == "SEXS"   || device == "GAST"    ||
+	  device == "SEXS"   || device == "GAST"    || device == "HYGOV" ||
           device == "ESST1A" || device == "ESST4B" || device == "GGOV1" ||
           device == "WSHYGP" || device == "TGOV1" || device == "PSSSIM") {
         ret = true;
@@ -1519,6 +1531,9 @@ class BasePTIParser : public BaseParser<_network>
               parser.parse(split_line, data, g_id);
 	    } else if (sval == "GAST") {
               GastParser<gen_params> parser;
+              parser.parse(split_line, data, g_id);
+	    } else if (sval == "HYGOV") {
+              HygovParser<gen_params> parser;
               parser.parse(split_line, data, g_id);
             } else if (sval == "WSHYGP") {
               WshygpParser<gen_params> parser;
@@ -1719,6 +1734,9 @@ class BasePTIParser : public BaseParser<_network>
             parser.store(split_line,data);
 	  } else if (sval == "GAST") {
             GastParser<gen_params> parser;
+            parser.store(split_line,data);
+	  } else if (sval == "HYGOV") {
+            HygovParser<gen_params> parser;
             parser.store(split_line,data);
           } else if (sval == "WSHYGP") {
             WshygpParser<gen_params> parser;

--- a/src/parser/dictionary.hpp
+++ b/src/parser/dictionary.hpp
@@ -3023,6 +3023,28 @@
 #define GOVERNOR_K "GOVERNOR_K"
 
 /**
+ * Governor TR
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_TR "GOVERNOR_TR"
+
+/**
+ * Governor TG
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_TG "GOVERNOR_TG"
+
+/**
+ * Governor TW
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_TW "GOVERNOR_TW"
+
+
+/**
  * Governor T1
  * type: real float
  * indexed
@@ -3275,6 +3297,13 @@
 #define GOVERNOR_R "GOVERNOR_R"
 
 /**
+ * Governor r
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_r "GOVERNOR_r"
+
+/**
  * Governor TPELEC
  * type: real float
  * indexed
@@ -3336,6 +3365,35 @@
  * indexed
  */
 #define GOVERNOR_VMIN "GOVERNOR_VMIN"
+
+/**
+ * Governor VELM
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_VELM "GOVERNOR_VELM"
+
+/**
+ * Governor GMAX
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_GMAX "GOVERNOR_GMAX"
+
+/**
+ * Governor GMIN
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_GMIN "GOVERNOR_GMIN"
+
+/**
+ * Governor QNL
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_QNL "GOVERNOR_QNL"
+
 
 /**
  * Governor TACT

--- a/src/parser/dictionary.hpp
+++ b/src/parser/dictionary.hpp
@@ -3422,6 +3422,20 @@
 #define GOVERNOR_DT "GOVERNOR_DT"
 
 /**
+ * Governor AT
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_AT "GOVERNOR_AT"
+/**
+ * Governor KT
+ * type: real float
+ * indexed
+ */
+#define GOVERNOR_KT "GOVERNOR_KT"
+
+
+/**
  * Governor DT
  * type: real float
  * indexed

--- a/src/parser/dictionary.hpp
+++ b/src/parser/dictionary.hpp
@@ -3633,6 +3633,13 @@
 #define EXCITER_TR "EXCITER_TR"
 
 /**
+ * Exciter K
+ * type: real float
+ * indexed
+ */
+#define EXCITER_K "EXCITER_K"
+
+/**
  * Exciter KA
  * type: real float
  * indexed
@@ -3654,6 +3661,13 @@
 #define EXCITER_TB "EXCITER_TB"
 
 /**
+ * Exciter TA_OVER_TB
+ * type: real float
+ * indexed
+ */
+#define EXCITER_TA_OVER_TB "EXCITER_TA_OVER_TB"
+
+/**
  * Exciter TC
  * type: real float
  * indexed
@@ -3673,6 +3687,21 @@
  * indexed
  */
 #define EXCITER_VRMIN "EXCITER_VRMIN"
+
+/**
+ * Exciter EMAX
+ * type: real float
+ * indexed
+ */
+#define EXCITER_EMAX "EXCITER_EMAX"
+
+/**
+ * Exciter EMIN
+ * type: real float
+ * indexed
+ */
+#define EXCITER_EMIN "EXCITER_EMIN"
+
 
 /**
  * Exciter KE

--- a/src/parser/parser_classes/gast.hpp
+++ b/src/parser/parser_classes/gast.hpp
@@ -1,0 +1,309 @@
+/*
+ *    Copyright (c) 2013 Battelle Memorial Institute
+ *    Licensed under modified BSD License. A copy of this license can be found
+ *    in the LICENSE file in the top level directory of this distribution.
+ */
+/*
+ *  Created on: November 7, 2022
+ *      Author: Shrirang Abhyankar
+ */
+#ifndef GAST_HPP
+#define GAST_HPP
+#include "gridpack/component/data_collection.hpp"
+#include "gridpack/parser/dictionary.hpp"
+#include "gridpack/utilities/string_utils.hpp"
+namespace gridpack {
+namespace parser {
+template <class _data_struct> class GastParser
+{
+  public:
+    /**
+     * Constructor
+     */
+    explicit GastParser()
+    {
+    }
+
+    /**
+     * Destructor
+     */
+    virtual ~GastParser()
+    {
+    }
+
+    /**
+     * Extract data from _data_struct and store it in data collection object
+     * @param data_struct data struct object
+     * @param data data collection object
+     * @param gen_id index of generator
+     */
+    void extract(_data_struct &data_struct,
+        gridpack::component::DataCollection *data, int g_id)
+    {
+      double rval;
+      bool bval;
+      // HAS_GOVERNOR
+      if (!data->getValue(HAS_GOVERNOR,&bval,g_id)) {
+        data->addValue(HAS_GOVERNOR, true, g_id);
+      } else {
+        data->setValue(HAS_GOVERNOR, true, g_id);
+      }
+
+      // GOVERNOR_NAME
+      std::string stmp;
+      if (!data->getValue(GOVERNOR_MODEL, &stmp, g_id)) {
+        data->addValue(GOVERNOR_MODEL, data_struct.model, g_id);
+      } else {
+        data->setValue(GOVERNOR_MODEL, data_struct.model, g_id);
+      }
+
+      // GOVERNOR_R
+      if (!data->getValue(GOVERNOR_R,&rval,g_id)) {
+        data->addValue(GOVERNOR_R, data_struct.gv_r, g_id);
+      } else {
+        data->setValue(GOVERNOR_R, data_struct.gv_r, g_id);
+      }
+
+      // GOVERNOR_T1
+      if (!data->getValue(GOVERNOR_T1,&rval,g_id)) {
+        data->addValue(GOVERNOR_T1, data_struct.gv_t1, g_id);
+      } else {
+        data->setValue(GOVERNOR_T1, data_struct.gv_t1, g_id);
+      }
+
+      // GOVERNOR_T2
+      if (!data->getValue(GOVERNOR_T2,&rval,g_id)) {
+        data->addValue(GOVERNOR_T2, data_struct.gv_t2, g_id);
+      } else {
+        data->setValue(GOVERNOR_T2, data_struct.gv_t2, g_id);
+      }
+
+      // GOVERNOR_T3
+      if (!data->getValue(GOVERNOR_T3,&rval,g_id)) {
+        data->addValue(GOVERNOR_T3, data_struct.gv_t3, g_id);
+      } else {
+        data->setValue(GOVERNOR_T3, data_struct.gv_t3, g_id);
+      }
+
+      // GOVERNOR_AT
+      if (!data->getValue(GOVERNOR_AT,&rval,g_id)) {
+        data->addValue(GOVERNOR_AT, data_struct.gv_at, g_id);
+      } else {
+        data->setValue(GOVERNOR_AT, data_struct.gv_at, g_id);
+      }
+
+      // GOVERNOR_KT
+      if (!data->getValue(GOVERNOR_KT,&rval,g_id)) {
+        data->addValue(GOVERNOR_KT, data_struct.gv_kt, g_id);
+      } else {
+        data->setValue(GOVERNOR_KT, data_struct.gv_kt, g_id);
+      }
+
+      // GOVERNOR_VMAX
+      if (!data->getValue(GOVERNOR_VMAX,&rval,g_id)) {
+        data->addValue(GOVERNOR_VMAX, data_struct.vmax, g_id);
+      } else {
+        data->setValue(GOVERNOR_VMAX, data_struct.vmax, g_id);
+      }
+
+      // GOVERNOR_VMIN
+      if (!data->getValue(GOVERNOR_VMIN,&rval,g_id)) {
+        data->addValue(GOVERNOR_VMIN, data_struct.vmin, g_id);
+      } else {
+        data->setValue(GOVERNOR_VMIN, data_struct.vmin, g_id);
+      }
+
+      // GOVERNOR_DT
+      if (!data->getValue(GOVERNOR_DT,&rval,g_id)) {
+        data->addValue(GOVERNOR_DT, data_struct.gv_dt, g_id);
+      } else {
+        data->setValue(GOVERNOR_DT, data_struct.gv_dt, g_id);
+      }
+    }
+
+    /**
+     * Parser list of strings and store results in data collection object
+     * @param split_line list of tokens from .dyr file
+     * @param data data collection object
+     * @param gen_id index of generator
+     */
+    void parse(std::vector<std::string> &split_line,
+        gridpack::component::DataCollection *data, int g_id)
+    {
+      double rval;
+      int nstr = split_line.size();
+      bool bval;
+      // HAS_GOVERNOR
+      if (!data->getValue(HAS_GOVERNOR,&bval,g_id)) {
+        data->addValue(HAS_GOVERNOR, true, g_id);
+      } else {
+        data->setValue(HAS_GOVERNOR, true, g_id);
+      }
+
+      // GOVERNOR_MODEL
+      std::string stmp, model;
+      gridpack::utility::StringUtils util;
+      model = util.trimQuotes(split_line[1]);
+      util.toUpper(model);
+      if (!data->getValue(GOVERNOR_MODEL,&stmp,g_id)) {
+        data->addValue(GOVERNOR_MODEL, model.c_str(), g_id);
+      } else {
+        data->setValue(GOVERNOR_MODEL, model.c_str(), g_id);
+      }
+
+      // GOVERNOR_R
+      if (nstr > 3) {
+        if (!data->getValue(GOVERNOR_R,&rval,g_id)) {
+          data->addValue(GOVERNOR_R, atof(split_line[3].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_R, atof(split_line[3].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_T1
+      if (nstr > 4) {
+        if (!data->getValue(GOVERNOR_T1,&rval,g_id)) {
+          data->addValue(GOVERNOR_T1, atof(split_line[4].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_T1, atof(split_line[4].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_T2
+      if (nstr > 5) {
+        if (!data->getValue(GOVERNOR_T2,&rval,g_id)) {
+          data->addValue(GOVERNOR_T2, atof(split_line[5].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_T2, atof(split_line[5].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_T3
+      if (nstr > 6) {
+        if (!data->getValue(GOVERNOR_T3,&rval,g_id)) {
+          data->addValue(GOVERNOR_T3, atof(split_line[6].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_T3, atof(split_line[6].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_AT
+      if (nstr > 7) {
+        if (!data->getValue(GOVERNOR_AT,&rval,g_id)) {
+          data->addValue(GOVERNOR_AT, atof(split_line[7].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_AT, atof(split_line[7].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_KT
+      if (nstr > 8) {
+        if (!data->getValue(GOVERNOR_KT,&rval,g_id)) {
+          data->addValue(GOVERNOR_KT, atof(split_line[8].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_KT, atof(split_line[8].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_VMAX
+      if (nstr > 9) {
+        if (!data->getValue(GOVERNOR_VMAX,&rval,g_id)) {
+          data->addValue(GOVERNOR_VMAX, atof(split_line[9].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_VMAX, atof(split_line[9].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_VMIN
+      if (nstr > 10) {
+        if (!data->getValue(GOVERNOR_VMIN,&rval,g_id)) {
+          data->addValue(GOVERNOR_VMIN, atof(split_line[10].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_VMIN, atof(split_line[10].c_str()), g_id);
+        }
+      } 
+
+      // GOVERNOR_DT
+      if (nstr > 11) {
+        if (!data->getValue(GOVERNOR_DT,&rval,g_id)) {
+          data->addValue(GOVERNOR_DT, atof(split_line[11].c_str()), g_id);
+        } else {
+          data->setValue(GOVERNOR_DT, atof(split_line[11].c_str()), g_id);
+        }
+      } 
+    }
+
+    /**
+     * Parse list of strings store results in data_struct object
+     * @param split_line list of tokens from .dyr file
+     * @param data data struct that stores information from file
+     */
+    void store(std::vector<std::string> &split_line,_data_struct &data)
+    {
+      // GOVERNOR_BUSNUMBER               "I"                   integer
+      int o_idx;
+      o_idx = atoi(split_line[0].c_str());
+      data.bus_id = o_idx;
+
+      // Clean up 2 character tag for generator ID
+      gridpack::utility::StringUtils util;
+      std::string tag = util.clean2Char(split_line[2]);
+      strcpy(data.gen_id, tag.c_str());
+
+      std::string sval;
+      sval = util.trimQuotes(split_line[1]);
+      util.toUpper(sval);
+
+      // GOVERNOR_MODEL              "MODEL"                  integer
+      strcpy(data.model, sval.c_str());
+
+      int nstr = split_line.size();
+      // GOVERNOR_R
+      if (nstr > 3) {
+        data.gv_r = atof(split_line[3].c_str());
+      }
+
+      // GOVERNOR_T1
+      if (nstr > 4) {
+        data.gv_t1 = atof(split_line[4].c_str());
+      }
+
+      // GOVERNOR_T2
+      if (nstr > 5) {
+        data.gv_t2 = atof(split_line[5].c_str());
+      }
+
+      // GOVERNOR_T3
+      if (nstr > 6) {
+        data.gv_t3 = atof(split_line[6].c_str());
+      }
+
+      // GOVERNOR_AT
+      if (nstr > 7) {
+        data.gv_at = atof(split_line[7].c_str());
+      }
+
+      // GOVERNOR_KT
+      if (nstr > 8) {
+        data.gv_kt = atof(split_line[8].c_str());
+      }
+
+      // GOVERNOR_VMAX
+      if (nstr > 9) {
+        data.vmax = atof(split_line[9].c_str());
+      }
+
+      // GOVERNOR_VMIN
+      if (nstr > 10) {
+        data.vmin = atof(split_line[10].c_str());
+      }
+
+      // GOVERNOR_DT
+      if (nstr > 11) {
+        data.gv_dt = atof(split_line[11].c_str());
+      }
+    }
+};
+}  // parser
+}  // gridpack
+#endif

--- a/src/parser/parser_classes/sexs.hpp
+++ b/src/parser/parser_classes/sexs.hpp
@@ -1,0 +1,262 @@
+/*
+ *    Copyright (c) 2013 Battelle Memorial Institute
+ *    Licensed under modified BSD License. A copy of this license can be found
+ *    in the LICENSE file in the top level directory of this distribution.
+ */
+/*
+ *  Created on: June 17, 2016
+ *      Author: Bruce Palmer
+ */
+#ifndef SEXS_HPP
+#define SEXS_HPP
+#include "gridpack/component/data_collection.hpp"
+#include "gridpack/parser/dictionary.hpp"
+#include "gridpack/utilities/string_utils.hpp"
+namespace gridpack {
+namespace parser {
+template <class _data_struct> class SexsParser
+{
+  public:
+    /**
+     * Constructor
+     */
+    explicit SexsParser()
+    {
+    }
+
+    /**
+     * Destructor
+     */
+    virtual ~SexsParser()
+    {
+    }
+
+    /**
+     * Extract data from _data_struct and store it in data collection object
+     * @param data_struct data struct object
+     * @param data data collection object
+     * @param gen_id index of generator
+     */
+    void extract(_data_struct &data_struct,
+        gridpack::component::DataCollection *data, int g_id)
+    {
+      double rval;
+      bool bval;
+      // HAS_EXCITER
+      if (!data->getValue(HAS_EXCITER,&bval,g_id)) {
+        data->addValue(HAS_EXCITER, true, g_id);
+      } else {
+        data->setValue(HAS_EXCITER, true, g_id);
+      }
+
+      // EXCITER_MODEL
+      std::string stmp;
+      if (!data->getValue(EXCITER_MODEL, &stmp, g_id)) {
+        data->addValue(EXCITER_MODEL, data_struct.model, g_id);
+      } else {
+        data->setValue(EXCITER_MODEL, data_struct.model, g_id);
+      }
+
+      // EXCITER_TA_OVER_TB
+      if (!data->getValue(EXCITER_TA_OVER_TB,&rval,g_id)) {
+        data->addValue(EXCITER_TA_OVER_TB, data_struct.ex_ta_over_tb, g_id);
+      } else {
+        data->setValue(EXCITER_TA_OVER_TB, data_struct.ex_ta_over_tb, g_id);
+      }
+
+      // EXCITER_TB
+      if (!data->getValue(EXCITER_TB,&rval,g_id)) {
+        data->addValue(EXCITER_TB, data_struct.ex_tb, g_id);
+      } else {
+        data->setValue(EXCITER_TB, data_struct.ex_tb, g_id);
+      }
+
+      // EXCITER_K
+      if (!data->getValue(EXCITER_K,&rval,g_id)) {
+        data->addValue(EXCITER_K, data_struct.ex_k, g_id);
+      } else {
+        data->setValue(EXCITER_K, data_struct.ex_k, g_id);
+      }
+
+      // EXCITER_TE
+      if (!data->getValue(EXCITER_TE,&rval,g_id)) {
+        data->addValue(EXCITER_TE, data_struct.ex_te, g_id);
+      } else {
+        data->setValue(EXCITER_TE, data_struct.ex_te, g_id);
+      }
+
+
+      // EXCITER_EMIN
+      if (!data->getValue(EXCITER_EMIN,&rval,g_id)) {
+        data->addValue(EXCITER_EMIN, data_struct.ex_emin, g_id);
+      } else {
+        data->setValue(EXCITER_EMIN, data_struct.ex_emin, g_id);
+      }
+
+      // EXCITER_EMAX
+      if (!data->getValue(EXCITER_EMAX,&rval,g_id)) {
+        data->addValue(EXCITER_EMAX, data_struct.ex_emax, g_id);
+      } else {
+        data->setValue(EXCITER_EMAX, data_struct.ex_emax, g_id);
+      }
+    }
+
+    /**
+     * Parser list of strings and store results in data collection object
+     * @param split_line list of tokens from .dyr file
+     * @param data data collection object
+     * @param gen_id index of generator
+     */
+    void parse(std::vector<std::string> &split_line,
+        gridpack::component::DataCollection *data, int g_id)
+    {
+      double rval;
+      bool bval;
+      int nstr = split_line.size();
+      // HAS_EXCITER
+      if (!data->getValue(HAS_EXCITER,&bval,g_id)) {
+        data->addValue(HAS_EXCITER, true, g_id);
+      } else {
+        data->setValue(HAS_EXCITER, true, g_id);
+      }
+
+      // EXCITER_MODEL
+      std::string stmp, model;
+      gridpack::utility::StringUtils util;
+      model = util.trimQuotes(split_line[1]);
+      util.toUpper(model);
+      if (!data->getValue(EXCITER_MODEL,&stmp,g_id)) {
+        data->addValue(EXCITER_MODEL, model.c_str(), g_id);
+      } else {
+        data->setValue(EXCITER_MODEL, model.c_str(), g_id);
+      }
+
+      // EXCITER_TA_OVER_TB
+      if (nstr > 3) {
+        if (!data->getValue(EXCITER_TA_OVER_TB,&rval,g_id)) {
+          data->addValue(EXCITER_TA_OVER_TB,
+              atof(split_line[3].c_str()), g_id);
+        } else {
+          data->setValue(EXCITER_TA_OVER_TB,
+              atof(split_line[3].c_str()), g_id);
+        }
+      } 
+
+      // EXCITER_TB
+      if (nstr > 4) {
+        if (!data->getValue(EXCITER_TB,&rval,g_id)) {
+          data->addValue(EXCITER_TB,
+              atof(split_line[4].c_str()), g_id);
+        } else {
+          data->setValue(EXCITER_TB,
+              atof(split_line[4].c_str()), g_id);
+        }
+      } 
+
+      // EXCITER_K
+      if (nstr > 5) {
+        if (!data->getValue(EXCITER_K,&rval,g_id)) {
+          data->addValue(EXCITER_K,
+              atof(split_line[5].c_str()), g_id);
+        } else {
+          data->setValue(EXCITER_K,
+              atof(split_line[5].c_str()), g_id);
+        }
+      }
+
+      // EXCITER_TE
+      if (nstr > 6) {
+        if (!data->getValue(EXCITER_TE,&rval,g_id)) {
+          data->addValue(EXCITER_TE,
+              atof(split_line[6].c_str()), g_id);
+        } else {
+          data->setValue(EXCITER_TE,
+              atof(split_line[6].c_str()), g_id);
+        }
+      }
+
+      // EXCITER_EMIN
+      if (nstr > 7) {
+        if (!data->getValue(EXCITER_EMIN,&rval,g_id)) {
+          data->addValue(EXCITER_EMIN,
+              atof(split_line[7].c_str()), g_id);
+        } else {
+          data->setValue(EXCITER_EMIN,
+              atof(split_line[7].c_str()), g_id);
+        }
+      }
+
+      // EXCITER_EMAX
+      if (nstr > 8) {
+        if (!data->getValue(EXCITER_EMAX,&rval,g_id)) {
+          data->addValue(EXCITER_EMAX,
+              atof(split_line[8].c_str()), g_id);
+        } else {
+          data->setValue(EXCITER_EMAX,
+              atof(split_line[8].c_str()), g_id);
+        }
+      } 
+    }
+
+    /**
+     * Parse list of strings store results in data_struct object
+     * @param split_line list of tokens from .dyr file
+     * @param data data struct that stores information from file
+     */
+    void store(std::vector<std::string> &split_line,_data_struct &data)
+    {
+      // EXCITER_BUSNUMBER               "I"                   integer
+      int o_idx;
+      o_idx = atoi(split_line[0].c_str());
+      data.bus_id = o_idx;
+
+      // Clean up 2 character tag for generator ID
+      gridpack::utility::StringUtils util;
+      std::string tag = util.clean2Char(split_line[2]);
+      strcpy(data.gen_id, tag.c_str());
+
+      std::string sval;
+      double rval;
+      int ival;
+
+      sval = util.trimQuotes(split_line[1]);
+      util.toUpper(sval);
+
+      // EXCITER_MODEL              "MODEL"                  integer
+      strcpy(data.model, sval.c_str());
+
+      int nstr = split_line.size();
+      // EXCITER_TA_OVER_TB
+      if (nstr > 3) {
+        data.ex_ta_over_tb = atof(split_line[3].c_str());
+      }
+
+      // EXCITER_TB
+      if (nstr > 4) {
+        data.ex_tb = atof(split_line[4].c_str());
+      }
+
+      // EXCITER_K
+      if (nstr > 5) {
+        data.ex_k = atof(split_line[5].c_str());
+      }
+
+      // EXCITER_TE
+      if (nstr > 6) {
+        data.ex_te = atof(split_line[6].c_str());
+      }
+
+      // EXCITER_EMIN
+      if (nstr > 7) {
+        data.ex_emin = atof(split_line[7].c_str());
+      }
+
+      // EXCITER_EMAX
+      if (nstr > 8) {
+        data.ex_emax = atof(split_line[8].c_str());
+      }
+    }
+};
+}  // parser
+}  // gridpack
+#endif


### PR DESCRIPTION
Adds three new dynamic models
- GAST : Gast steam turbine governor
- HYGOV : Hydro turbine governor
- SEXS : Simplified exciter model

In addition, a new class for first order linear control blocks called `cblock` is added to ease the implementation of new models. This class encapsulates all the essential operations for a first order linear control block and takes care of all the state update and other book-keeping details. The model developer simply has to interact with the block through its inputs/outputs. Four specific implementations of this first linear control blocks - PI Controller, LeadLag, Integrator, and Filter - are implemented. 