### PR TITLE
Fix parser renewable

### DIFF
--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -698,10 +698,10 @@ class BasePTIParser : public BaseParser<_network>
       double wind_kpc;
       double wind_kcc;
       double wind_tp;
-      double wind_tetamax;
-      double wind_tetamin;
-      double wind_rtetamax;
-      double wind_rtetamin;
+      double wind_thetamax;
+      double wind_thetamin;
+      double wind_rthetamax;
+      double wind_rthetamin;
       double wind_kpp;
       double wind_kip;
       double wind_twref;

--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -1718,7 +1718,8 @@ class BasePTIParser : public BaseParser<_network>
       while(std::getline(input,line)) {
         // Check to see if line is blank
         int idx = line.find_first_not_of(' ');
-        if (idx == std::string::npos) continue;
+	int idx2 = line.find_first_not_of('\r'); // Some systems use \r\n for line ends.
+        if (idx == std::string::npos || idx2 == std::string::npos) continue;
         // Check to see if line is a comment
         if (line[idx] == '/') {
           if (line.length() > idx+2 && line[idx+1] == '/') {

--- a/src/parser/dictionary.hpp
+++ b/src/parser/dictionary.hpp
@@ -5644,28 +5644,28 @@
  * type: real float
  * indexed
  */
-#define WIND_PC_TETAMAX "WIND_PC_TETAMAX"
+#define WIND_PC_THETAMAX "WIND_PC_THETAMAX"
 
 /**
  * Minimum pitch angle
  * type: real float
  * indexed
  */
-#define WIND_PC_TETAMIN "WIND_PC_TETAMIN"
+#define WIND_PC_THETAMIN "WIND_PC_THETAMIN"
 
 /**
  * Maximum pitch angle rate
  * type: real float
  * indexed
  */
-#define WIND_PC_RTETAMAX "WIND_PC_RTETAMAX"
+#define WIND_PC_RTHETAMAX "WIND_PC_RTHETAMAX"
 
 /**
  * Minimum pitch angle rate
  * type: real float
  * indexed
  */
-#define WIND_PC_RTETAMIN "WIND_PC_RTETAMIN"
+#define WIND_PC_RTHETAMIN "WIND_PC_RTHETAMIN"
 
 /**
  * Proportional gain in torque regulator

--- a/src/parser/parser_classes/wtpta1.hpp
+++ b/src/parser/parser_classes/wtpta1.hpp
@@ -107,32 +107,32 @@ template <class _data_struct> class Wtpta1Parser
         data->setValue(WIND_PC_TP, data_struct.wind_tp, g_id);
       }
 
-      // WIND_TETAMAX
-      if (!data->getValue(WIND_PC_TETAMAX,&rval,g_id)) {
-        data->addValue(WIND_PC_TETAMAX, data_struct.wind_tetamax, g_id);
+      // WIND_THETAMAX
+      if (!data->getValue(WIND_PC_THETAMAX,&rval,g_id)) {
+        data->addValue(WIND_PC_THETAMAX, data_struct.wind_thetamax, g_id);
       } else {
-        data->setValue(WIND_PC_TETAMAX, data_struct.wind_tetamax, g_id);
+        data->setValue(WIND_PC_THETAMAX, data_struct.wind_thetamax, g_id);
       }
 
-      // WIND_TETAMIN
-      if (!data->getValue(WIND_PC_TETAMIN,&rval,g_id)) {
-        data->addValue(WIND_PC_TETAMIN, data_struct.wind_tetamin, g_id);
+      // WIND_THETAMIN
+      if (!data->getValue(WIND_PC_THETAMIN,&rval,g_id)) {
+        data->addValue(WIND_PC_THETAMIN, data_struct.wind_thetamin, g_id);
       } else {
-        data->setValue(WIND_PC_TETAMIN, data_struct.wind_tetamin, g_id);
+        data->setValue(WIND_PC_THETAMIN, data_struct.wind_thetamin, g_id);
       }
 
-      // WIND_RTETAMAX
-      if (!data->getValue(WIND_PC_RTETAMAX,&rval,g_id)) {
-        data->addValue(WIND_PC_RTETAMAX, data_struct.wind_rtetamax, g_id);
+      // WIND_RTHETAMAX
+      if (!data->getValue(WIND_PC_RTHETAMAX,&rval,g_id)) {
+        data->addValue(WIND_PC_RTHETAMAX, data_struct.wind_rthetamax, g_id);
       } else {
-        data->setValue(WIND_PC_RTETAMAX, data_struct.wind_rtetamax, g_id);
+        data->setValue(WIND_PC_RTHETAMAX, data_struct.wind_rthetamax, g_id);
       }
 
-      // WIND_RTETAMIN
-      if (!data->getValue(WIND_PC_RTETAMIN,&rval,g_id)) {
-        data->addValue(WIND_PC_RTETAMIN, data_struct.wind_rtetamin, g_id);
+      // WIND_RTHETAMIN
+      if (!data->getValue(WIND_PC_RTHETAMIN,&rval,g_id)) {
+        data->addValue(WIND_PC_RTHETAMIN, data_struct.wind_rthetamin, g_id);
       } else {
-        data->setValue(WIND_PC_RTETAMIN, data_struct.wind_rtetamin, g_id);
+        data->setValue(WIND_PC_RTHETAMIN, data_struct.wind_rthetamin, g_id);
       }
     }
 
@@ -226,34 +226,34 @@ template <class _data_struct> class Wtpta1Parser
       }
 
       if (nstr > 9) {
-        if (!data->getValue(WIND_PC_TETAMAX,&rval,g_id)) {
-          data->addValue(WIND_PC_TETAMAX, atof(split_line[9].c_str()), g_id);
+        if (!data->getValue(WIND_PC_THETAMAX,&rval,g_id)) {
+          data->addValue(WIND_PC_THETAMAX, atof(split_line[9].c_str()), g_id);
         } else {
-          data->setValue(WIND_PC_TETAMAX, atof(split_line[9].c_str()), g_id);
+          data->setValue(WIND_PC_THETAMAX, atof(split_line[9].c_str()), g_id);
         }
       }
 
       if (nstr > 10) {
-        if (!data->getValue(WIND_PC_TETAMIN,&rval,g_id)) {
-          data->addValue(WIND_PC_TETAMIN, atof(split_line[10].c_str()), g_id);
+        if (!data->getValue(WIND_PC_THETAMIN,&rval,g_id)) {
+          data->addValue(WIND_PC_THETAMIN, atof(split_line[10].c_str()), g_id);
         } else {
-          data->setValue(WIND_PC_TETAMIN, atof(split_line[10].c_str()), g_id);
+          data->setValue(WIND_PC_THETAMIN, atof(split_line[10].c_str()), g_id);
         }
       }
 
       if (nstr > 11) {
-        if (!data->getValue(WIND_PC_RTETAMAX,&rval,g_id)) {
-          data->addValue(WIND_PC_RTETAMAX, atof(split_line[11].c_str()), g_id);
+        if (!data->getValue(WIND_PC_RTHETAMAX,&rval,g_id)) {
+          data->addValue(WIND_PC_RTHETAMAX, atof(split_line[11].c_str()), g_id);
         } else {
-          data->setValue(WIND_PC_RTETAMAX, atof(split_line[11].c_str()), g_id);
+          data->setValue(WIND_PC_RTHETAMAX, atof(split_line[11].c_str()), g_id);
         }
       }
 
       if (nstr > 12) {
-        if (!data->getValue(WIND_PC_RTETAMIN,&rval,g_id)) {
-          data->addValue(WIND_PC_RTETAMIN, atof(split_line[12].c_str()), g_id);
+        if (!data->getValue(WIND_PC_RTHETAMIN,&rval,g_id)) {
+          data->addValue(WIND_PC_RTHETAMIN, atof(split_line[12].c_str()), g_id);
         } else {
-          data->setValue(WIND_PC_RTETAMIN, atof(split_line[12].c_str()), g_id);
+          data->setValue(WIND_PC_RTHETAMIN, atof(split_line[12].c_str()), g_id);
         }
       }
     }
@@ -312,19 +312,19 @@ template <class _data_struct> class Wtpta1Parser
       }
 
       if (nstr > 9) {
-        data.wind_tetamax = atof(split_line[9].c_str());
+        data.wind_thetamax = atof(split_line[9].c_str());
       }
 
       if (nstr > 10) {
-        data.wind_tetamin = atof(split_line[10].c_str());
+        data.wind_thetamin = atof(split_line[10].c_str());
       }
 
       if (nstr > 11) {
-        data.wind_rtetamax = atof(split_line[11].c_str());
+        data.wind_rthetamax = atof(split_line[11].c_str());
       }
 
       if (nstr > 12) {
-        data.wind_rtetamin = atof(split_line[12].c_str());
+        data.wind_rthetamin = atof(split_line[12].c_str());
       }
     }
 };

--- a/src/utilities/string_utils.hpp
+++ b/src/utilities/string_utils.hpp
@@ -224,7 +224,9 @@ public:
         if (ntok2 == std::string::npos) ntok2 = slen;
       } 
       if (ntok1 != std::string::npos && ntok2 != std::string::npos) {
-        ret.push_back(strcpy.substr(ntok1,ntok2-ntok1));
+	std::string field = strcpy.substr(ntok1,ntok2-ntok1);
+	if((field.find_first_not_of(' ',0) != std::string::npos) &&  (field.find_first_not_of('\r',0) != std::string::npos))
+	  ret.push_back(field);
       }
     }
     return ret;


### PR DESCRIPTION
Fixes for parsing renewable model correctly on MacOS systems . On MacOS, carriage return `\r` is added to the newline `\n` character that causes the parser for renewable generators (and perhaps other models as well) to not work correctly. This change fixes this issue.