### PR TITLE
GENROU: Fix error in corrector current injection.

### DIFF
--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.cpp
@@ -481,8 +481,8 @@ void gridpack::dynamic_simulation::GenrouGenerator::corrector_currentInjection(b
   G = Ra / (Ra * Ra + Xdpp * Xdpp);
   //printf("B = %f, G = %f\n", B, G);
   // Setup
-  double Psiqpp = - x6Edp * (Xqpp - Xl) / (Xqp - Xl) - x5Psiqp * (Xqp - Xqpp) / (Xqp - Xl); 
-  double Psidpp = + x3Eqp * (Xdpp - Xl) / (Xdp - Xl) + x4Psidp * (Xdp - Xdpp) / (Xdp - Xl); 
+  double Psiqpp = - x6Edp_1 * (Xqpp - Xl) / (Xqp - Xl) - x5Psiqp_1 * (Xqp - Xqpp) / (Xqp - Xl); 
+  double Psidpp = + x3Eqp_1 * (Xdpp - Xl) / (Xdp - Xl) + x4Psidp_1 * (Xdp - Xdpp) / (Xdp - Xl); 
   double Vd = -Psiqpp * (1 + x2w_1);
   double Vq = +Psidpp * (1 + x2w_1);
   Vterm = presentMag;


### PR DESCRIPTION
GENROU corrector current injection should use updated (predictor) states. Couple of states were missing using these values.