### PR TITLE
Forgot to add gridpack_block_parsers to install directory for external builds

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -229,3 +229,9 @@ install (FILES
   variable_defs/misc_defs.hpp
   DESTINATION include/gridpack/parser/variable_defs
 )
+
+install(TARGETS 
+  gridpack_block_parsers
+  DESTINATION lib
+  )
+


### PR DESCRIPTION
This is a quick fix to make sure that the gridpack_block_parsers lib ends up in the install/lib directory for external builds.