### PR TITLE
Enable printing of matrices and vectors ffor dynamic simulation application

### DIFF
--- a/src/applications/dynamic_simulation_full_y/dsf_main.cpp
+++ b/src/applications/dynamic_simulation_full_y/dsf_main.cpp
@@ -67,7 +67,7 @@ int
 main(int argc, char **argv)
 {
   gridpack::NoPrint *noprint_ins = gridpack::NoPrint::instance();
-  noprint_ins->setStatus(true);
+  noprint_ins->setStatus(false);
   
   // Initialize MPI libraries
   int ierr = MPI_Init(&argc, &argv);


### PR DESCRIPTION
Setting true for gridpack::NoPrint status causes side effect of not printing gridpack matrices and vectors to sdout. See #125. Even PETSc viewing functions `VecView` and `MatView` do not work. The fix is to set the status to false. Closes #125 