### PR TITLE
Updates for renewable energy model benchmarking

### DIFF
--- a/src/applications/components/pf_matrix/pf_components.cpp
+++ b/src/applications/components/pf_matrix/pf_components.cpp
@@ -493,14 +493,16 @@ void gridpack::powerflow::PFBus::load(
       ok =  data->getValue(GENERATOR_PMAX,&pt,i);
       ok =  data->getValue(GENERATOR_PMIN,&pb,i);
       if (lgen) {
-        p_pg.push_back(pg);
-        p_savePg.push_back(pg);
-        p_qg.push_back(qg);
         p_gstatus.push_back(gstatus);
         if (gstatus == 0) {
           qmax = 0.0;
           qmin = 0.0;
+	  pg = 0.0;
+	  qg = 0.0;
         }
+	p_pg.push_back(pg);
+        p_savePg.push_back(pg);
+        p_qg.push_back(qg);
         p_pFac.push_back(qmax);
         p_qmax.push_back(qmax);
         qtot += qmax;
@@ -1015,15 +1017,17 @@ bool gridpack::powerflow::PFBus::serialWrite(char *string, const int bufsize,
       }
     }
     for (i=0; i<ngen; i++) {
-      double pval;
-      double qval;
+      double pval = 0.0;
+      double qval = 0.0;
 
       if(getReferenceBus()) {
 	pval = p_pFac[i]*(p_Pinj*p_sbase+pl);
 	qval = p_pFac[i]*(p_Qinj*p_sbase+ql);
       } else if (p_isPV) {
 	pval = p_pg[i];
-	qval = p_pFac[i]*(p_Qinj*p_sbase+ql);
+	if(p_gstatus[i]) {
+	  qval = p_pFac[i]*(p_Qinj*p_sbase+ql);
+	}
       } else {
 	pval = p_pg[i];
 	qval = p_qg[i];

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/reeca1.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/reeca1.cpp
@@ -296,8 +296,7 @@ void gridpack::dynamic_simulation::Reeca1Model::init(double Vm, double Va,
       Q_Pfflag = V_err_PI_blk_in + Vt_filter - Vbias;
     } else {
       Q_PI_blk_in = Q_PI_blk.init_given_y(V_err_PI_blk_in + Vt_filter);
-      // ***** TO BE IMPLEMENTED ***
-      // Need to get Qelec
+      Q_Pfflag = Q_PI_blk_in + Qgen;
     }
   }
 
@@ -427,10 +426,9 @@ void gridpack::dynamic_simulation::Reeca1Model::computeModel(bool Voltage_dip,in
     if(!VFLAG) {
       Vlim_blk_in = Qext + Vbias;
     } else {
-      // ******* Not implemented yet
-      // Need to get Qelec
-      // Calculate Vlim_blk_in
-      // *************
+      double Qlim_blk_out;
+      Qlim_blk_out = Qlim_blk.getoutput(Qext);
+      Vlim_blk_in = Q_PI_blk.getoutput(Qlim_blk_out - Qgen);
     }
     double Verr_PI_blk_in;
     Verr_PI_blk_in = Vlim_blk.getoutput(Vlim_blk_in);

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/regca1.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/regca1.cpp
@@ -272,7 +272,7 @@ gridpack::ComplexType gridpack::dynamic_simulation::Regca1Generator::INorton()
 
   Iq_olim = std::max(0.0,khv*(Vt - volim));
 
-  Iqout = Iqlowlim_blk.getoutput(Iq + Iq_olim);
+  Iqout = Iqlowlim_blk.getoutput(Iq - Iq_olim);
 
   transform(Ipout,Iqout,theta,&Irout,&Iiout);
 
@@ -321,7 +321,7 @@ void gridpack::dynamic_simulation::Regca1Generator::computeModel(double t_inc, I
 
   Iq_olim = std::max(0.0,khv*(Vt - volim));
 
-  Iqout = Iqlowlim_blk.getoutput(Iq + Iq_olim);
+  Iqout = Iqlowlim_blk.getoutput(Iq - Iq_olim);
 
   // Pg, Qg on machine MVAbase
   Pg = Vt*Ipout;
@@ -441,9 +441,9 @@ void gridpack::dynamic_simulation::Regca1Generator::computeModel(double t_inc, I
   if(lvplsw) {
     Lvpl_out = Lvpl_blk.getoutput(Vt_filter);
 
-    Ip = Ip_blk.getoutput(Ipcmd,t_inc,-1000.0,1000.0,-1000.0,Lvpl_out*rrpwr,-1000.0,1000.0,int_flag,true);
+    Ip = Ip_blk.getoutput(Ipcmd,t_inc,-1000.0,Lvpl_out,-1000.0,rrpwr,-1000.0,1000.0,int_flag,true);
   } else {
-    Ip = Ip_blk.getoutput(Ipcmd,t_inc,int_flag,true);
+    Ip = Ip_blk.getoutput(Ipcmd,t_inc,-1000.0,1000.0,-1000.0,rrpwr,-1000.0,1000.0,int_flag,true);
   }
 				   
   Iq = Iq_blk.getoutput(Iqcmd,t_inc,int_flag,true);

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/repca1.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/repca1.cpp
@@ -161,18 +161,19 @@ void gridpack::dynamic_simulation::Repca1Model::init(double Vm, double Va, doubl
     
     temp = Qbranch_filter_blk.init_given_u(Qbranch);
   } else {
+    double V_VFLAG;
     if(!VCompFLAG) {
-      double V_VFLAG;
+
       Qbranch = Qg;
       V_VFLAG = Qbranch*Kc + Vt;
-
-      V_filter_blk_out = V_filter_blk.init_given_u(V_VFLAG);
-      Vref = V_filter_blk_out;
     } else {
-      // **************
-      // **** TO BE IMPLEMENTED
-      // *************
+      // Only considering Vt, line drop compensation
+      // needs to be implemented in full implementation
+      // This also means Rc = Xc = 0 in the file
+      V_VFLAG = Vt;
     }
+    V_filter_blk_out = V_filter_blk.init_given_u(V_VFLAG);
+    Vref = V_filter_blk_out;
   }
 }
 
@@ -210,8 +211,10 @@ void gridpack::dynamic_simulation::Repca1Model::computeModel(double t_inc,Integr
     y_VCompFLAG = Qbranch*Kc + Vt;
   } else {
     // **************
-    // *** Not implemented yet
+    // Line drop compensation not implemented,
+    // Only considering voltage control
     // *************
+    y_VCompFLAG = Vt;
   }
 
   if(!RefFLAG) {

--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -1102,6 +1102,7 @@ class BasePTIParser : public BaseParser<_network>
             parser.extract(gen_data[i], data, g_id);
 	  } else if (!strcmp(gen_data[i].model,"IEEET1")) {
             Ieeet1Parser<gen_params> parser;
+	    parser.extract(gen_data[i], data, g_id);
           } else if (!strcmp(gen_data[i].model,"ESST1A")) {
             Esst1aParser<gen_params> parser;
             parser.extract(gen_data[i], data, g_id);

--- a/src/parser/base_pti_parser.hpp
+++ b/src/parser/base_pti_parser.hpp
@@ -1795,6 +1795,9 @@ class BasePTIParser : public BaseParser<_network>
 
           // Clean up 2 character tag for generator ID
           std::string tag = util.clean2Char(split_line[2]);
+	  
+
+	  
           strcpy(data.gen_id, tag.c_str());
 
           double rval;

--- a/src/parser/block_parsers/transformer_parser33.cpp
+++ b/src/parser/block_parsers/transformer_parser33.cpp
@@ -420,8 +420,9 @@ void gridpack::parser::TransformerParser33::parse(
        * type: integer
        * TRANSFORMER_CW
        */
+      int cw = atoi(split_line[4].c_str());
       p_branchData[l_idx]->addValue(TRANSFORMER_CW,
-          atoi(split_line[4].c_str()),nelems);
+          cw,nelems);
 
       /*
        * type: integer
@@ -543,7 +544,15 @@ void gridpack::parser::TransformerParser33::parse(
       ntoken = split_line3.size();
       double windv1 = atof(split_line3[0].c_str());
       double windv2 = atof(split_line4[0].c_str());
+
+      if(cw == 2) {
+	double nomv1 = atof(split_line3[1].c_str());
+	double nomv2 = atof(split_line4[1].c_str());
+	windv1 = windv1/nomv1;
+	windv2 = windv2/nomv2;
+      }
       double tap = windv1/windv2;
+      
       p_branchData[l_idx]->addValue(BRANCH_TAP,tap,nelems);
       p_branchData[l_idx]->addValue(TRANSFORMER_WINDV1,windv1,nelems);
       p_branchData[l_idx]->addValue(TRANSFORMER_WINDV2,windv2,nelems);

--- a/src/parser/block_parsers/transformer_parser34.cpp
+++ b/src/parser/block_parsers/transformer_parser34.cpp
@@ -456,8 +456,9 @@ void gridpack::parser::TransformerParser34::parse(
        * type: integer
        * TRANSFORMER_CW
        */
+      int cw =  atoi(split_line[4].c_str()); 
       p_branchData[l_idx]->addValue(TRANSFORMER_CW,
-          atoi(split_line[4].c_str()),nelems);
+         cw,nelems);
 
       /*
        * type: integer
@@ -579,6 +580,12 @@ void gridpack::parser::TransformerParser34::parse(
       ntoken = split_line3.size();
       double windv1 = atof(split_line3[0].c_str());
       double windv2 = atof(split_line4[0].c_str());
+      if(cw == 2) {
+	double nomv1 = atof(split_line3[1].c_str());
+	double nomv2 = atof(split_line4[1].c_str());
+	windv1 = windv1/nomv1;
+	windv2 = windv2/nomv2;
+      }
       double tap = windv1/windv2;
       p_branchData[l_idx]->addValue(BRANCH_TAP,tap,nelems);
       p_branchData[l_idx]->addValue(TRANSFORMER_WINDV1,windv1,nelems);

--- a/src/parser/block_parsers/transformer_parser35.cpp
+++ b/src/parser/block_parsers/transformer_parser35.cpp
@@ -456,8 +456,9 @@ void gridpack::parser::TransformerParser35::parse(
        * type: integer
        * TRANSFORMER_CW
        */
+      int cw = atoi(split_line[4].c_str()); 
       p_branchData[l_idx]->addValue(TRANSFORMER_CW,
-          atoi(split_line[4].c_str()),nelems);
+         cw,nelems);
 
       /*
        * type: integer
@@ -579,6 +580,12 @@ void gridpack::parser::TransformerParser35::parse(
       ntoken = split_line3.size();
       double windv1 = atof(split_line3[0].c_str());
       double windv2 = atof(split_line4[0].c_str());
+      if(cw == 2) {
+	double nomv1 = atof(split_line3[1].c_str());
+	double nomv2 = atof(split_line4[1].c_str());
+	windv1 = windv1/nomv1;
+	windv2 = windv2/nomv2;
+      }
       double tap = windv1/windv2;
       p_branchData[l_idx]->addValue(BRANCH_TAP,tap,nelems);
       p_branchData[l_idx]->addValue(TRANSFORMER_WINDV1,windv1,nelems);

--- a/src/parser/parser_classes/reeca1.hpp
+++ b/src/parser/parser_classes/reeca1.hpp
@@ -841,6 +841,7 @@ template <class _data_struct> class Reeca1Parser
       // Clean up 2 character tag for generator ID
       gridpack::utility::StringUtils util;
       std::string tag = util.clean2Char(split_line[2]);
+      
       strcpy(data.gen_id, tag.c_str());
 
       std::string sval;

--- a/src/utilities/string_utils.hpp
+++ b/src/utilities/string_utils.hpp
@@ -60,6 +60,12 @@ public:
       ntok++;
       ntok = str.find('\t',ntok);
     }
+    ntok = str.find('\r',0);
+    while (ntok != std::string::npos) {
+      str[ntok] = ' ';
+      ntok++;
+      ntok = str.find('\r',ntok);
+    }
     boost::trim(str);
   };
 
@@ -129,6 +135,11 @@ public:
     } else {
       clean_tag = tag;
     }
+
+    // Some systems put \r if the id is at the end of the line. remove it and put a space.
+      if(clean_tag.size() == 2 && clean_tag[clean_tag.size() - 1] == '\r')
+	clean_tag[1] = ' ';
+
     return clean_tag;
   }
 


### PR DESCRIPTION
These updates were made for benchmarking IEEE-39 bus system with renewable energy models.

- Fixed transformer tap calculation when the winding voltage is specified.
- Fix generrator output for OFF status generators
- Fix /r character issue with gen id parsing.
- Bug fix in IEEET1 parsing
- Added missing control logic paths for REECA1 and REPCA1
- Fix low voltage active power block rate and state limits.

* The test system cannot be uploaded at the moment for proprietary reasons.