### PR TITLE
Installation scripts

### DIFF
--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -13,7 +13,7 @@ install_gridpack_python=true
 
 # Set your python executable here
 python_exe=`which python`
-if[ -z ${python_exe}]
+if test -z ${python_exe}
 then
     python_exe=`which python3`
 fi

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -39,19 +39,22 @@ then
   rm -rf $GRIDPACK_BUILD_DIR
   mkdir $GRIDPACK_BUILD_DIR
 
+  rm -rf ${GRIDPACK_INSTALL_DIR}
+
   cd ${GRIDPACK_BUILD_DIR}
     
   ## GridPACK installation
-  echo "Building GridPACK develop branch"
+  echo "Building GridPACK"
 
-  git checkout develop
+#  git checkout develop
 
   rm -rf CMake*
 
   cmake_args="-D GA_DIR:STRING=${GP_EXT_DEPS}/ga-5.8/install_for_gridpack \
    -D BOOST_ROOT:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack \    
-   -D Boost_DIR:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib/cmake/Boost-1.78.0 \   
-   -D BOOST_LIBRARIES:STRING=${GP_EXT_DEPS}/boost_1_78_0/build/lib \   
+   -D Boost_DIR:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib/cmake/Boost-1.78.0 \
+   -D Boost_LIBRARIES:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib \   
+   -D Boost_INCLUDE_DIRS:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/include \
    -D PETSC_DIR:PATH=${GP_EXT_DEPS}/petsc/install_for_gridpack \                  
    -D MPI_CXX_COMPILER:STRING='mpicxx' \     
    -D MPI_C_COMPILER:STRING='mpicc' \                                         
@@ -82,6 +85,8 @@ then
 
     export RHEL_OPENMPI_HACK=yes
 
+    rm -rf build
+    
     ${python_exe} setup.py build
 
     rm -rf ${GRIDPACK_INSTALL_DIR}/lib/python
@@ -92,5 +97,7 @@ then
     ${python_exe} setup.py install --home="$GRIDPACK_DIR"
     
 fi
+
+cd ${GRIDPACK_ROOT_DIR}
 
 echo "Completed GridPACK installation"

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -1,0 +1,123 @@
+# This script installs GridPACK and all its dependencies.The dependencies are installed in external-dependencies directory. GridPACK is built in src/build directory and installed in src/install directory.
+
+# This script should be run from the top-level GridPACK directory.
+
+# Set environment variable GRIDPACK_DIR
+export GRIDPACK_DIR=${PWD}
+
+# Create directory for installing external packages
+rm -rf external-dependencies
+mkdir external-dependencies
+
+cd external-dependencies
+
+export GP_EXT_DEPS=${PWD}
+
+# Download and install Boost
+echo "Downloading Boost-1.78.0"
+
+# Download Boost
+wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
+
+# Untar
+tar -xvf boost_1_78_0.tar.gz
+
+cd boost_1_78_0
+
+# Install boost
+echo "Building Boost-1.78.0"
+
+./bootstrap.sh --prefix=install_for_gridpack --with-libraries=mpi,serialization,random,filesystem
+
+cat project-config.jam >> `using mpi ;`
+
+./b2 -a -d+2 link=shared stage
+
+echo "Installing Boost-1.78.0"
+./b2 -a -d+2 link=shared install
+
+echo "Building and Installing Boost libraries complete"
+
+# Download, build, and install GA
+cd ..
+
+echo "Downloading GA-5.8"
+
+wget https://github.com/GlobalArrays/ga/releases/download/v5.8/ga-5.8.tar.gz
+
+tar -xvf ga-5.8.tar.gz
+
+cd ga-5.8
+
+# Build GA
+echo "Building GA-5.8"
+./configure --with-mpi-ts --disable-f77 --without-blas --enable-cxx --enable-i4 --prefix=${PWD}/install_for_gridpack --enable-shared
+
+# Install GA
+echo "Installing GA-5.8"
+make -j 10 install
+
+echo "GA-5.8 installation complete"
+
+
+# Install PETSc 3.16.4
+cd ..
+
+# Download
+echo "Downloading PETSc 3.16.4"
+
+git clone https://gitlab.com/petsc/petsc.githttps://gitlab.com/petsc/petsc.git
+
+git checkout v3.16.4
+
+cd petsc
+
+export PETSC_DIR=${PWD}
+export PETSC_ARCH=build-dir
+
+# Install PETSc
+echo "Installing PETSc 3.16.4"
+
+./configure --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake --prefix=${PWD}/install_for_gridpack --scalar-type=complex --with-shared-libraries=1 --download-f2cblaslapack=1 --download-cmake=1
+
+# Build PETSc
+echo "Building PETSc 3.16.4"
+
+make
+
+# Install PETSc
+echo "Installing PETSc 3.16.4"
+
+make install
+make check
+
+## GridPACK installation
+echo "Building GridPACK develop branch"
+
+git checkout develop
+
+cd ${GRIDPACK_DIR}/src
+
+rm -rf build
+mkdir build
+
+cd build
+
+rm -rf CMake*                                                                               
+cmake \                                                                                     
+   -D GA_DIR:STRING=${GP_EXT_DEPS}/ga-5.8/install_for_gridpack \
+   -D BOOST_ROOT:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack \    
+   -D Boost_DIR:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib/cmake/Boost-1.78.0 \   
+   -D BOOST_LIBRARYDIR:STRING=${GP_EXT_DEPS}/boost_1_78_0/build/lib \   
+   -D PETSC_DIR:PATH=${GP_EXT_DEPS}/petsc/install_for_gridpack \                  
+   -D MPI_CXX_COMPILER:STRING='mpicxx' \     
+   -D MPI_C_COMPILER:STRING='mpicc' \                                         
+   -D MPIEXEC:STRING='mpiexec' \                                                            
+   -D GRIDPACK_TEST_TIMEOUT:STRING=30 \                                                     
+   -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_DIR}/src/install \             
+   -D CMAKE_BUILD_TYPE:STRING=Debug \
+   -D BUILD_SHARED_LIBS=YES \
+    ..   
+
+echo "Installing GridPACK develop branch"
+make -j 10 install

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -12,7 +12,11 @@ install_gridpack=true
 install_gridpack_python=true
 
 # Set your python executable here
-python_exe=`which python3`
+python_exe=`which python`
+if[ -z ${python_exe}]
+then
+    python_exe=`which python3`
+fi
 
 # Install log file
 install_log_file=${PWD}/install.log
@@ -126,6 +130,7 @@ then
 fi  
 
 GRIDPACK_INSTALL_DIR=${GRIDPACK_ROOT_DIR}/src/install
+export GRIDPACK_DIR=${GRIDPACK_INSTALL_DIR}
 
 if ${install_gridpack}
 then
@@ -168,7 +173,6 @@ then
     
     git submodule update --init
 
-    export GRIDPACK_DIR=${GRIDPACK_INSTALL_DIR}
     echo ${GRIDPACK_DIR}
     cd python
 

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -1,11 +1,6 @@
-# This script installs GridPACK and all its dependencies.The dependencies are installed in src/build/external-dependencies directory. GridPACK is built in src/build directory and installed in src/install directory.
+# This script installs GridPACK and python wrappter.GridPACK is built in src/build directory and installed in src/install directory.
 
 # This script should be run from the top-level GridPACK directory.
-
-# Flags for installing/not installing different dependency packages
-install_boost=true
-install_ga=true
-install_petsc=true
 
 # Flag for install GridPACK and GridPACK python wrapper
 install_gridpack=true
@@ -18,122 +13,31 @@ then
     python_exe=`which python3`
 fi
 
-# Install log file
-install_log_file=${PWD}/install.log
-
-echo 'GRIDPACK installation log file' > ${install_log_file}
-echo $(date) >> install_log_file
-
-export GRIDPACK_ROOT_DIR=${PWD}
-# Set environment variable GRIDPACK_BUILD_DIR and create a build directory
-export GRIDPACK_BUILD_DIR=${GRIDPACK_ROOT_DIR}/src/build
-
-rm -rf $GRIDPACK_BUILD_DIR
-mkdir $GRIDPACK_BUILD_DIR
-cd $GRIDPACK_BUILD_DIR
+if test -z ${GRIDPACK_ROOT_DIR}
+then
+    export GRIDPACK_ROOT_DIR=${PWD}
+    echo "GRIDPACK_ROOT_DIR = ${GRIDPACK_ROOT_DIR}"
+fi
 
 # Create directory for installing external packages
-mkdir external-dependencies
-
-export GP_EXT_DEPS=${GRIDPACK_BUILD_DIR}/external-dependencies
-
-cd external-dependencies
-
-if ${install_boost}
+if test -z ${GP_EXT_DEPS}
 then
-
-  rm -rf boost*
-    
-  # Download and install Boost
-  echo "Downloading Boost-1.78.0"
-
-  # Download Boost
-  wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz &>> ${install_log_file}
-
-  # Untar
-  tar -xf boost_1_78_0.tar.gz
-
-  cd boost_1_78_0
-
-  # Install boost
-  echo "Building Boost-1.78.0"
-
-  ./bootstrap.sh --prefix=install_for_gridpack --with-libraries=mpi,serialization,random,filesystem,system &>> ${install_log_file}
-
-  echo 'using mpi ;' >> project-config.jam
-
-  ./b2 -a -d+2 link=shared stage &>> ${install_log_file}
-
-  echo "Installing Boost-1.78.0"
-  ./b2 -a -d+2 link=shared install &>> ${install_log_file}
-
-  echo "Building and Installing Boost libraries complete"
+     export GP_EXT_DEPS=${GRIDPACK_ROOT_DIR}/external-dependencies
 fi
 
-if ${install_ga}
-then
-  # Download, build, and install GA
-  cd ${GP_EXT_DEPS}
+cd ${GRIDPACK_ROOT_DIR}
 
-  echo "Downloading GA-5.8"
-
-  wget https://github.com/GlobalArrays/ga/releases/download/v5.8/ga-5.8.tar.gz  &>> ${install_log_file}
-
-  tar -xf ga-5.8.tar.gz  &>> ${install_log_file}
-
-  cd ga-5.8
-
-  # Build GA
-  echo "Building GA-5.8"
-  ./configure --with-mpi-ts --disable-f77 --without-blas --enable-cxx --enable-i4 --prefix=${PWD}/install_for_gridpack --enable-shared &>> ${install_log_file}
-  
-  # Install GA
-  echo "Installing GA-5.8"
-  make -j 10 install &>> ${install_log_file}
-  
-  echo "GA-5.8 installation complete"
-fi
-
-if ${install_petsc}
-then
-    
-  # Install PETSc 3.16.4
-  cd ${GP_EXT_DEPS}
-
-  # Download
-  echo "Downloading PETSc 3.16.4"
-
-  git clone https://gitlab.com/petsc/petsc.git &>> ${install_log_file}
-    
-  cd petsc
-
-  git checkout tags/v3.16.4 -b v3.16.4  &>> ${install_log_file}
-
-  export PETSC_DIR=${PWD}
-  export PETSC_ARCH=build-dir
-
-  # Install PETSc
-  echo "Installing PETSc 3.16.4"
-    
-  ./configure --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake --prefix=${PWD}/install_for_gridpack --scalar-type=complex --with-shared-libraries=1 --download-f2cblaslapack=1  &>> ${install_log_file}
-
-  # Build PETSc
-  echo "Building PETSc 3.16.4"
-
-  make  &>> ${install_log_file}
-
-  # Install PETSc
-  echo "Installing PETSc 3.16.4"
-
-  make install  &>> ${install_log_file}
-  make check  &>> ${install_log_file}
-fi  
+# Set environment variable GRIDPACK_BUILD_DIR and create a build directory
+export GRIDPACK_BUILD_DIR=${GRIDPACK_ROOT_DIR}/src/build
 
 GRIDPACK_INSTALL_DIR=${GRIDPACK_ROOT_DIR}/src/install
 export GRIDPACK_DIR=${GRIDPACK_INSTALL_DIR}
 
 if ${install_gridpack}
 then
+
+  rm -rf $GRIDPACK_BUILD_DIR
+  mkdir $GRIDPACK_BUILD_DIR
 
   cd ${GRIDPACK_BUILD_DIR}
     
@@ -188,9 +92,5 @@ then
     ${python_exe} setup.py install --home="$GRIDPACK_DIR"
     
 fi
-
-# update LD_LIBRARY_PATH so that boost,ga, and petsc are on it
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib:${GP_EXT_DEPS}/ga-5.8/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib
-cd ${GRIDPACK_ROOT_DIR}
 
 echo "Completed GridPACK installation"

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -1,123 +1,192 @@
-# This script installs GridPACK and all its dependencies.The dependencies are installed in external-dependencies directory. GridPACK is built in src/build directory and installed in src/install directory.
+# This script installs GridPACK and all its dependencies.The dependencies are installed in src/build/external-dependencies directory. GridPACK is built in src/build directory and installed in src/install directory.
 
 # This script should be run from the top-level GridPACK directory.
 
-# Set environment variable GRIDPACK_DIR
-export GRIDPACK_DIR=${PWD}
+# Flags for installing/not installing different dependency packages
+install_boost=true
+install_ga=true
+install_petsc=true
+
+# Flag for install GridPACK and GridPACK python wrapper
+install_gridpack=true
+install_gridpack_python=true
+
+# Set your python executable here
+python_exe=`which python3`
+
+# Install log file
+install_log_file=${PWD}/install.log
+
+echo 'GRIDPACK installation log file' > ${install_log_file}
+echo $(date) >> install_log_file
+
+export GRIDPACK_ROOT_DIR=${PWD}
+# Set environment variable GRIDPACK_BUILD_DIR and create a build directory
+export GRIDPACK_BUILD_DIR=${GRIDPACK_ROOT_DIR}/src/build
+
+rm -rf $GRIDPACK_BUILD_DIR
+mkdir $GRIDPACK_BUILD_DIR
+cd $GRIDPACK_BUILD_DIR
 
 # Create directory for installing external packages
-rm -rf external-dependencies
 mkdir external-dependencies
+
+export GP_EXT_DEPS=${GRIDPACK_BUILD_DIR}/external-dependencies
 
 cd external-dependencies
 
-export GP_EXT_DEPS=${PWD}
+if ${install_boost}
+then
 
-# Download and install Boost
-echo "Downloading Boost-1.78.0"
+  rm -rf boost*
+    
+  # Download and install Boost
+  echo "Downloading Boost-1.78.0"
 
-# Download Boost
-wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
+  # Download Boost
+  wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz &>> ${install_log_file}
 
-# Untar
-tar -xvf boost_1_78_0.tar.gz
+  # Untar
+  tar -xf boost_1_78_0.tar.gz
 
-cd boost_1_78_0
+  cd boost_1_78_0
 
-# Install boost
-echo "Building Boost-1.78.0"
+  # Install boost
+  echo "Building Boost-1.78.0"
 
-./bootstrap.sh --prefix=install_for_gridpack --with-libraries=mpi,serialization,random,filesystem
+  ./bootstrap.sh --prefix=install_for_gridpack --with-libraries=mpi,serialization,random,filesystem,system &>> ${install_log_file}
 
-cat project-config.jam >> `using mpi ;`
+  echo 'using mpi ;' >> project-config.jam
 
-./b2 -a -d+2 link=shared stage
+  ./b2 -a -d+2 link=shared stage &>> ${install_log_file}
 
-echo "Installing Boost-1.78.0"
-./b2 -a -d+2 link=shared install
+  echo "Installing Boost-1.78.0"
+  ./b2 -a -d+2 link=shared install &>> ${install_log_file}
 
-echo "Building and Installing Boost libraries complete"
+  echo "Building and Installing Boost libraries complete"
+fi
 
-# Download, build, and install GA
-cd ..
+if ${install_ga}
+then
+  # Download, build, and install GA
+  cd ${GP_EXT_DEPS}
 
-echo "Downloading GA-5.8"
+  echo "Downloading GA-5.8"
 
-wget https://github.com/GlobalArrays/ga/releases/download/v5.8/ga-5.8.tar.gz
+  wget https://github.com/GlobalArrays/ga/releases/download/v5.8/ga-5.8.tar.gz  &>> ${install_log_file}
 
-tar -xvf ga-5.8.tar.gz
+  tar -xf ga-5.8.tar.gz  &>> ${install_log_file}
 
-cd ga-5.8
+  cd ga-5.8
 
-# Build GA
-echo "Building GA-5.8"
-./configure --with-mpi-ts --disable-f77 --without-blas --enable-cxx --enable-i4 --prefix=${PWD}/install_for_gridpack --enable-shared
+  # Build GA
+  echo "Building GA-5.8"
+  ./configure --with-mpi-ts --disable-f77 --without-blas --enable-cxx --enable-i4 --prefix=${PWD}/install_for_gridpack --enable-shared &>> ${install_log_file}
+  
+  # Install GA
+  echo "Installing GA-5.8"
+  make -j 10 install &>> ${install_log_file}
+  
+  echo "GA-5.8 installation complete"
+fi
 
-# Install GA
-echo "Installing GA-5.8"
-make -j 10 install
+if ${install_petsc}
+then
+    
+  # Install PETSc 3.16.4
+  cd ${GP_EXT_DEPS}
 
-echo "GA-5.8 installation complete"
+  # Download
+  echo "Downloading PETSc 3.16.4"
 
+  git clone https://gitlab.com/petsc/petsc.git &>> ${install_log_file}
+    
+  cd petsc
 
-# Install PETSc 3.16.4
-cd ..
+  git checkout tags/v3.16.4 -b v3.16.4  &>> ${install_log_file}
 
-# Download
-echo "Downloading PETSc 3.16.4"
+  export PETSC_DIR=${PWD}
+  export PETSC_ARCH=build-dir
 
-git clone https://gitlab.com/petsc/petsc.githttps://gitlab.com/petsc/petsc.git
+  # Install PETSc
+  echo "Installing PETSc 3.16.4"
+    
+  ./configure --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake --prefix=${PWD}/install_for_gridpack --scalar-type=complex --with-shared-libraries=1 --download-f2cblaslapack=1  &>> ${install_log_file}
 
-git checkout v3.16.4
+  # Build PETSc
+  echo "Building PETSc 3.16.4"
 
-cd petsc
+  make  &>> ${install_log_file}
 
-export PETSC_DIR=${PWD}
-export PETSC_ARCH=build-dir
+  # Install PETSc
+  echo "Installing PETSc 3.16.4"
 
-# Install PETSc
-echo "Installing PETSc 3.16.4"
+  make install  &>> ${install_log_file}
+  make check  &>> ${install_log_file}
+fi  
 
-./configure --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake --prefix=${PWD}/install_for_gridpack --scalar-type=complex --with-shared-libraries=1 --download-f2cblaslapack=1 --download-cmake=1
+GRIDPACK_INSTALL_DIR=${GRIDPACK_ROOT_DIR}/src/install
 
-# Build PETSc
-echo "Building PETSc 3.16.4"
+if ${install_gridpack}
+then
 
-make
+  cd ${GRIDPACK_BUILD_DIR}
+    
+  ## GridPACK installation
+  echo "Building GridPACK develop branch"
 
-# Install PETSc
-echo "Installing PETSc 3.16.4"
+  git checkout develop
 
-make install
-make check
+  rm -rf CMake*
 
-## GridPACK installation
-echo "Building GridPACK develop branch"
-
-git checkout develop
-
-cd ${GRIDPACK_DIR}/src
-
-rm -rf build
-mkdir build
-
-cd build
-
-rm -rf CMake*                                                                               
-cmake \                                                                                     
-   -D GA_DIR:STRING=${GP_EXT_DEPS}/ga-5.8/install_for_gridpack \
+  cmake_args="-D GA_DIR:STRING=${GP_EXT_DEPS}/ga-5.8/install_for_gridpack \
    -D BOOST_ROOT:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack \    
    -D Boost_DIR:STRING=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib/cmake/Boost-1.78.0 \   
-   -D BOOST_LIBRARYDIR:STRING=${GP_EXT_DEPS}/boost_1_78_0/build/lib \   
+   -D BOOST_LIBRARIES:STRING=${GP_EXT_DEPS}/boost_1_78_0/build/lib \   
    -D PETSC_DIR:PATH=${GP_EXT_DEPS}/petsc/install_for_gridpack \                  
    -D MPI_CXX_COMPILER:STRING='mpicxx' \     
    -D MPI_C_COMPILER:STRING='mpicc' \                                         
    -D MPIEXEC:STRING='mpiexec' \                                                            
    -D GRIDPACK_TEST_TIMEOUT:STRING=30 \                                                     
-   -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_DIR}/src/install \             
+   -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_INSTALL_DIR} \             
    -D CMAKE_BUILD_TYPE:STRING=Debug \
    -D BUILD_SHARED_LIBS=YES \
-    ..   
+   -D Boost_NO_SYSTEM_PATHS:BOOL=TRUE \
+    ..   "
+ 
+  cmake ${cmake_args}                                                                                     
 
-echo "Installing GridPACK develop branch"
-make -j 10 install
+   echo "Installing GridPACK develop branch"
+   make -j 10 install
+fi
+
+if ${install_gridpack_python}
+then
+    echo "Installing GridPACK python wrapper"
+    
+    cd ${GRIDPACK_ROOT_DIR}
+    
+    git submodule update --init
+
+    export GRIDPACK_DIR=${GRIDPACK_INSTALL_DIR}
+    echo ${GRIDPACK_DIR}
+    cd python
+
+    export RHEL_OPENMPI_HACK=yes
+
+    ${python_exe} setup.py build
+
+    rm -rf ${GRIDPACK_INSTALL_DIR}/lib/python
+    mkdir ${GRIDPACK_INSTALL_DIR}/lib/python
+    
+    PYTHONPATH="${GRIDPACK_DIR}/lib/python:${PYTHONPATH}"
+    export PYTHONPATH
+    ${python_exe} setup.py install --home="$GRIDPACK_DIR"
+    
+fi
+
+# update LD_LIBRARY_PATH so that boost,ga, and petsc are on it
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib:${GP_EXT_DEPS}/ga-5.8/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib
+cd ${GRIDPACK_ROOT_DIR}
+
+echo "Completed GridPACK installation"

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -1,0 +1,126 @@
+# This script installs all GridPACK dependencies.The dependencies are installed in external-dependencies directory.
+
+# This script should be run from the top-level GridPACK directory.
+
+# Flags for installing/not installing different dependency packages
+install_boost=true
+install_ga=true
+install_petsc=true
+
+echo $(date)
+
+if test -z ${GRIDPACK_ROOT_DIR}
+then
+    export GRIDPACK_ROOT_DIR=${PWD}
+    echo "GRIDPACK_ROOT_DIR = ${GRIDPACK_ROOT_DIR}"
+fi
+
+cd ${GRIDPACK_ROOT_DIR}
+
+# Create directory for installing external packages
+if test -z ${GP_EXT_DEPS}
+then
+     export GP_EXT_DEPS=${GRIDPACK_ROOT_DIR}/external-dependencies
+     rm -rf ${GP_EXT_DEPS}
+     mkdir ${GP_EXT_DEPS}
+    echo "GRIDPACK_EXT_DEPENDENCIES_DIR=${GP_EXT_DEPS}"
+fi
+
+cd ${GP_EXT_DEPS}
+
+if ${install_boost}
+then
+
+  rm -rf boost*
+    
+  # Download and install Boost
+  echo "Downloading Boost-1.78.0"
+
+  # Download Boost
+  wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
+
+  # Untar
+  tar -xf boost_1_78_0.tar.gz
+
+  cd boost_1_78_0
+
+  # Install boost
+  echo "Building Boost-1.78.0"
+
+  ./bootstrap.sh --prefix=install_for_gridpack --with-libraries=mpi,serialization,random,filesystem,system
+
+  echo 'using mpi ;' >> project-config.jam
+
+  ./b2 -a -d+2 link=shared stage
+
+  echo "Installing Boost-1.78.0"
+  ./b2 -a -d+2 link=shared install
+
+  echo "Building and Installing Boost libraries complete"
+fi
+
+if ${install_ga}
+then
+  # Download, build, and install GA
+  cd ${GP_EXT_DEPS}
+
+  echo "Downloading GA-5.8"
+
+  wget https://github.com/GlobalArrays/ga/releases/download/v5.8/ga-5.8.tar.gz
+
+  tar -xf ga-5.8.tar.gz
+
+  cd ga-5.8
+
+  # Build GA
+  echo "Building GA-5.8"
+  ./configure --with-mpi-ts --disable-f77 --without-blas --enable-cxx --enable-i4 --prefix=${PWD}/install_for_gridpack --enable-shared
+  
+  # Install GA
+  echo "Installing GA-5.8"
+  make -j 10 install
+  
+  echo "GA-5.8 installation complete"
+fi
+
+if ${install_petsc}
+then
+    
+  # Install PETSc 3.16.4
+  cd ${GP_EXT_DEPS}
+
+  # Download
+  echo "Downloading PETSc 3.16.4"
+
+  git clone https://gitlab.com/petsc/petsc.git
+    
+  cd petsc
+
+  git checkout tags/v3.16.4 -b v3.16.4
+
+  export PETSC_DIR=${PWD}
+  export PETSC_ARCH=build-dir
+
+  # Install PETSc
+  echo "Installing PETSc 3.16.4"
+    
+  ./configure --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake --prefix=${PWD}/install_for_gridpack --scalar-type=complex --with-shared-libraries=1 --download-f2cblaslapack=1
+
+  # Build PETSc
+  echo "Building PETSc 3.16.4"
+
+  make 
+
+  # Install PETSc
+  echo "Installing PETSc 3.16.4"
+
+  make install
+  make check  
+fi  
+
+# update LD_LIBRARY_PATH so that boost,ga, and petsc are on it
+export LD_LIBRARY_PATH=${GP_EXT_DEPS}/boost_1_78_0/install_for_gridpack/lib:${GP_EXT_DEPS}/ga-5.8/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib:${LD_LIBRARY_PATH}
+
+cd ${GRIDPACK_ROOT_DIR}
+
+echo "Completed installing GridPACK dependencies in ${GP_EXT_DEPS}"

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -23,7 +23,14 @@ then
      export GP_EXT_DEPS=${GRIDPACK_ROOT_DIR}/external-dependencies
      rm -rf ${GP_EXT_DEPS}
      mkdir ${GP_EXT_DEPS}
-    echo "GRIDPACK_EXT_DEPENDENCIES_DIR=${GP_EXT_DEPS}"
+     echo "GRIDPACK_EXT_DEPENDENCIES_DIR=${GP_EXT_DEPS}"
+else
+    if test -d ${GP_EXT_DEPS}
+    then
+	echo "GRIDPACK_EXT_DEPENDENCIES_DIR=${GP_EXT_DEPS}"
+    else
+	mkdir ${GP_EXT_DEPS}
+    fi		
 fi
 
 cd ${GP_EXT_DEPS}

--- a/src/lib/GridPACK.cmake.in
+++ b/src/lib/GridPACK.cmake.in
@@ -238,10 +238,10 @@ function(gridpack_setup)
 #    @MPI_INCLUDE_PATH@
 #  )
 
-  list(APPEND gp_libs
-    @Boost_LIBRARIES@
-    @MPI_CXX_LIBRARIES@
-  )
+#  list(APPEND gp_libs
+#    @Boost_LIBRARIES@
+#    @MPI_CXX_LIBRARIES@
+#  )
 
   set(GRIDPACK_INCLUDE_DIRS
     ${gp_include}

--- a/src/lib/GridPACK.cmake.in
+++ b/src/lib/GridPACK.cmake.in
@@ -233,10 +233,10 @@ function(gridpack_setup)
     list(APPEND gp_libs @GLPK_LIBRARY@)
   endif()
 
-  list(APPEND gp_include 
-    @Boost_INCLUDE_DIRS@
-    @MPI_INCLUDE_PATH@
-  )
+#  list(APPEND gp_include 
+#    @Boost_INCLUDE_DIR@
+#    @MPI_INCLUDE_PATH@
+#  )
 
   list(APPEND gp_libs
     @Boost_LIBRARIES@


### PR DESCRIPTION
Added installation scripts for GridPACK. There are two scripts.
- install_gridpack_deps.sh : Install GridPACK dependency packages Boost, GlobalArrays, and PETSc
- install_gridpack.sh: Install GridPACK source and its python version

To install GridPACK, simply `source` these files.