### PR TITLE
Fix CMake cmp0026 policy warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,12 +15,6 @@
 # 
 cmake_minimum_required (VERSION 3.5.0)
 
-# This allows the use of LOCATION(target)
-if (POLICY CMP0026)
-  cmake_policy(SET CMP0026 OLD)
-endif (POLICY CMP0026)
-
-
 project (GridPACK)
 
 set (GridPACK_VERSION_MAJOR 3)

--- a/src/cmake-modules/GridPACK.cmake
+++ b/src/cmake-modules/GridPACK.cmake
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created June 10, 2013 by William A. Perkins
-# Last Change: 2023-08-28 13:18:39 d3g096
+# Last Change: 2023-12-13 07:00:00 d3g096
 # -------------------------------------------------------------
 
 
@@ -57,9 +57,9 @@ endmacro()
 # This provides a way to consistly add a test that uses Boost::Test
 # and can be executed on one processor without ${MPI_EXEC}.
 # -------------------------------------------------------------
-function(gridpack_add_serial_unit_test test_name test_program)
+function(gridpack_add_serial_unit_test test_name test_target)
   set(the_test_name "${test_name}_serial")
-  add_test("${the_test_name}" "${test_program}")
+  add_test("${the_test_name}" "${test_target}")
   set_tests_properties("${the_test_name}"
     PROPERTIES 
     PASS_REGULAR_EXPRESSION "No errors detected"
@@ -76,9 +76,9 @@ endfunction(gridpack_add_serial_unit_test)
 # on one processor without using ${MPI_EXEC}. Success or failure is
 # based on the exit code.
 # -------------------------------------------------------------
-function(gridpack_add_serial_run_test test_name test_program test_input)
+function(gridpack_add_serial_run_test test_name test_target test_input)
   set(the_test_name "${test_name}_serial")
-  add_test("${the_test_name}" "${test_program}" ${test_input})
+  add_test("${the_test_name}" "${test_target}" ${test_input})
   set_tests_properties("${the_test_name}"
     PROPERTIES 
     TIMEOUT ${GRIDPACK_TEST_TIMEOUT}
@@ -92,9 +92,8 @@ endfunction(gridpack_add_serial_run_test)
 function(gridpack_add_parallel_unit_test test_name test_target)
   set(the_test_name "${test_name}_parallel")
   if (TARGET ${test_target})
-    get_property(test_program TARGET ${test_target} PROPERTY LOCATION)
     add_test("${the_test_name}"
-      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ${test_program} ${MPIEXEC_POSTFLAGS})
+      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ${test_target} ${MPIEXEC_POSTFLAGS})
     set_tests_properties("${the_test_name}"
       PROPERTIES 
       PASS_REGULAR_EXPRESSION "No errors detected"
@@ -117,9 +116,8 @@ endfunction(gridpack_add_parallel_unit_test)
 function(gridpack_add_parallel_run_test test_name test_target test_input)
   set(the_test_name "${test_name}_parallel")
   if (TARGET ${test_target})
-    get_property(test_program TARGET ${test_target} PROPERTY LOCATION)
     add_test("${the_test_name}"
-      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ${test_program} ${MPIEXEC_POSTFLAGS} ${test_input})
+      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ${test_target} ${MPIEXEC_POSTFLAGS} ${test_input})
     set_tests_properties("${the_test_name}"
       PROPERTIES 
       TIMEOUT ${GRIDPACK_TEST_TIMEOUT}
@@ -138,12 +136,12 @@ endfunction(gridpack_add_parallel_run_test)
 # same executable
 # -------------------------------------------------------------
 
-function(gridpack_add_unit_test test_name test_program)
+function(gridpack_add_unit_test test_name test_target)
   if (NOT USE_PROGRESS_RANKS)
-    gridpack_add_serial_unit_test("${test_name}" ${test_program})
+    gridpack_add_serial_unit_test("${test_name}" ${test_target})
   endif()
   if (MPIEXEC) 
-    gridpack_add_parallel_unit_test("${test_name}" ${test_program})
+    gridpack_add_parallel_unit_test("${test_name}" ${test_target})
   endif ()
 endfunction(gridpack_add_unit_test)
 

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -247,7 +247,7 @@ elif [ $host == "tlaloc" ]; then
     cmake -Wdev --debug-trycompile \
         --graphviz=GridPACK.dot \
           -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.19.4" \
-          -D PETSC_ARCH:STRING="ubuntu-complex-shared" \
+          -D PETSC_ARCH:STRING="ubuntu-real-shared" \
           -D USE_OLD_PETSC:BOOL=OFF \
           -D BOOST_ROOT:PATH="/usr" \
           -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -246,9 +246,8 @@ elif [ $host == "tlaloc" ]; then
     prefix="$HOME/Projects/GridPakLDRD/gridpack-install"
     cmake -Wdev --debug-trycompile \
         --graphviz=GridPACK.dot \
-          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.19.4" \
+          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.14.6" \
           -D PETSC_ARCH:STRING="ubuntu-real-shared" \
-          -D USE_OLD_PETSC:BOOL=OFF \
           -D BOOST_ROOT:PATH="/usr" \
           -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
           -D PARMETIS_DIR:PATH="/usr" \


### PR DESCRIPTION
Unit testing relied on the executable target `LOCATION` property. For some time this has been deprecated.  This PR updates unit testing to stop using the `LOCATION` property.  Closes #33. 