### PR TITLE
Fix No dynamic model and/or load status bugs

### DIFF
--- a/src/applications/modules/dynamic_simulation_full_y/dsf_app_module2.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_app_module2.cpp
@@ -111,15 +111,15 @@ bool gridpack::dynamic_simulation::DSFullApp::solveNetwork(int predcorrflag)
 	its += 1;
       }
     }// end of while
-  }else {// p_biterative_solve_network = false
+  } else {// p_biterative_solve_network = false
     /* Non-iterative solution */
-   solver_sptr->solve(*INorton_full, *volt_full);
-   /* Push voltage to buses */
-   nbusMap_sptr->mapToBus(volt_full);
-   p_factory->setVolt(false);
-
-   converged = true;
- } // end of if (p_biterative_solve_network)
+    solver_sptr->solve(*INorton_full, *volt_full);
+    /* Push voltage to buses */
+    nbusMap_sptr->mapToBus(volt_full);
+    p_factory->setVolt(false);
+    
+    converged = true;
+  } // end of if (p_biterative_solve_network)
 
   return converged;
 }
@@ -207,6 +207,7 @@ void gridpack::dynamic_simulation::DSFullApp::setup()
 
   /* Voltage vector */
   volt_full.reset(INorton_full->clone());
+  volt_full->zero();
 
   /* Linear solver */
   solver_sptr.reset(new gridpack::math::LinearSolver (*ybus));

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
@@ -757,6 +757,7 @@ class DSFullBus
     bool p_sink;
     double p_rtpr_scale;
     std::vector<double> p_pg, p_qg, p_savePg, p_negpg, p_negqg, p_genpg_nodynmodel, p_genqg_nodynmodel;
+    std::vector<bool> p_gen_nodynmodel; // Generator does not have a dynamic model specificed in the dyr file
     std::vector<double> p_mva, p_r, p_dstr, p_dtr, p_gpmin, p_gpmax;
     int p_ngen, p_negngen, p_ngen_nodynmodel;
     int p_ndyn_load, p_npowerflow_load;


### PR DESCRIPTION
Fixed a couple of important bugs that would cause a crash or wrong initialization in dynamics simulation application
1.  Fixed crash in handling of generators with no dynamic model given in the dyr file. 
2. Fixed incorrect initialization of dynamics simulation application when the load status is 0 in the raw file.