### PR TITLE
Mac OS X Build

### DIFF
--- a/docs/markdown/BUILD_GRIDPACK.md
+++ b/docs/markdown/BUILD_GRIDPACK.md
@@ -24,13 +24,12 @@ More general information on configuring the GridPACK build can be found in the
 sections below and additional information on libraries used by GridPACK can be
 found [here](REQUIRED_SOFTWARE.md).
 
-* [Ubuntu Linux 16.04](DUMMY.md)
 * [Ubuntu Linux 18.04](DUMMY.md)
 * [Debian Linux](DUMMY.md)
 * [CentOS or RHEL 7](DUMMY.md)
 * [CentOS or RHEL 6](DUMMY.md)
 * [PNNL RC Cluster (Linux cluster with Infiniband)](platforms/RC_CLUSTER.md)
-* [Mac OS X (High Sierra) with MacPorts](DUMMY.md)
+* [Mac OS X Sonoma with MacPorts](platforms/MacOSX.md)
 
 If you run into problems, feel free to contact us for further help. You can also
 look at our [troubleshooting page](DUMMY.md).

--- a/docs/markdown/platforms/MacOSX.md
+++ b/docs/markdown/platforms/MacOSX.md
@@ -1,0 +1,259 @@
+Introduction
+============
+
+This details the building of GridPACK on a Macbook Pro running Mac OS X
+Sonoma (14.7.1). The build was aided by the use of
+[MacPorts](https://www.macports.org/) to install compilers and MPI.
+Super user permissions are required to install and manage
+[MacPorts](https://www.macports.org/).
+
+These instructions use a specific combination of compilers, MPI
+implementation, and [MacPorts](https://www.macports.org/) packages.
+Other combinations can be probably used, the one here happened to work
+for the author. If you choose some other combination, you\'re on your
+own.
+
+The author uses the C-shell. These instructions will need to be slightly
+modified to adapt to another shell, like `bash`.
+
+MacPorts
+========
+
+[MacPorts](https://www.macports.org/) is free, open source system
+whereby various software packages can be installed and maintained on a
+Mac OS X system. [Homebrew](https://brew.sh/) provides a similar
+capability, but the author has no experience with it.
+
+The [MacPorts](https://www.macports.org/) project provides very good
+[installation instructions](https://www.macports.org/install.php). They
+will not be repeated here. It is assumed here that
+[MacPorts](https://www.macports.org/) was installed in `/opt/local`,
+which is the default.
+
+After [MacPorts](https://www.macports.org/) installation,
+`/opt/local/bin` needs to be in shell search path. The easiest way to do
+this is to add `/opt/local/bin` to the top of `/etc/paths` (superuser
+privileges required). Afterward, a reboot or starting a new shell should
+make the `port` command availble on the command line.
+
+Packages from MacPorts
+----------------------
+
+Install the CLang 16.0 compiler set and mpich MPI implementation.
+
+    sudo port install mpich mpich-clang16
+    sudo port select --set clang mp-clang-16
+    sudo port select --set mpi mpich-clang16-fortran
+
+The latter commands make the installed compilers, and MPI wrappers the
+default. That way the compiler commands, `clang` and `clang++`, and MPI
+compiler wrappers, like `mpicc`, will be available at the command line.
+
+Python 3 is necessary, so a specific version was chosen. Whatever
+version should be adequate.
+
+    sudo port install python312
+    sudo port select --set python python312
+    sudo port select --set python3 python312
+
+Install CMake and other necessities:
+
+    sudo port install cmake
+    sudo port install pkgconfig
+
+Build Prerequisites from Source
+===============================
+
+[PETSc](http://www.mcs.anl.gov/petsc/) and [Global
+Arrays](http://www.emsl.pnl.gov/docs/global/) need to be built from
+source. You need to choose a path in which packages will be installed.
+Here the author decided to use `$HOME/Projects/GridPACK/install` as an
+installation directory. Below, it is assumed that `$prefix` is set
+
+    set prefix = $HOME/Projects/GridPACK/install
+
+In order to build the GridPACK Python interface, all prerequisites must
+be built as shared libraries.
+
+I tried to install Boost and PETSc via MacPorts. Boost, with proper
+variants, will install and is usable to GridPACK. However, PETSc 3.22
+could not be built with SuperLU or Suitesparse. This tends to break some
+solver unit tests. So, build from source.
+
+Global Arrays
+-------------
+
+GA version 5.8.2 source code was downloaded from the [Github
+site](https://github.com/GlobalArrays/ga/releases/download/v5.8.2/ga-5.8.2.tar.gz).
+Avoid cloning the Github repository, because preparing to build the code
+requires a full installation of GNU autotools (and that has been
+problematic for me).
+
+GA was configured and built as follows
+
+    cd ga-5.8.2
+    mkdir build
+    cd build
+    unsetenv CC
+    unsetenv CXX
+    ../configure --with-mpi-ts --disable-f77 \
+        --without-blas --without-lapack --without-scalapack \
+        --enable-cxx --enable-i4 \
+        --prefix=$prefix \
+        --enable-shared=yes --enable-static=no \
+        CFLAGS=-Wno-implicit-function-declaration
+    make -j
+    make -k check
+    make install
+
+Boost
+-----
+
+Boost version 1.81.0 was downloaded from
+[here](https://archives.boost.io/release/1.81.0/source/).
+
+In the past, it\'s tricky to get Boost build to use the MacPorts CLang,
+but it seems to work here. The build uses \"clang++\" on PATH rather
+than a full path.
+
+    ./bootstrap.sh --with-toolset=clang --prefix=$prefix \
+        --with-libraries=mpi,serialization,random,filesystem,system
+    echo 'using mpi : mpicxx ; ' >> project-config.jam
+    ./b2 -a -d+2 toolset=clang link=shared stage
+    ./b2 -a -d+2 toolset=clang link=shared install
+
+PETSc
+-----
+
+On modern Mac OS X, only PETSc version 3.20.1 and later can be used.
+Older versions will not build. This has been noted by others.
+
+    wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.6.tar.gz
+    tar xvzf petsc-3.20.6.tar.gz
+    cd petsc-3.20.6
+    unsetenv PETSC_ARCH
+    python ./configure \
+        PETSC_ARCH=mpich-clang-real-shared \
+        --prefix=$prefix \
+        --with-mpi=1 \
+        --with-gnu-compilers=0 \
+        --with-cc=/opt/local/bin/mpicc \
+        --with-fc=/opt/local/bin/mpif90 \
+        --with-cxx=/opt/local/bin/mpicxx \
+        --with-clanguage=c \
+        --with-fortran-bindings=0 \
+        --with-scalar-type=real \
+        --with-precision=double \
+        --download-cmake=0 \
+        --download-suitesparse=1 \
+        --download-superlu_dist=1 \
+        --download-superlu=1 \
+        --download-parmetis=1 \
+        --download-metis=1 \
+        --download-f2cblaslapack=1 \
+        --download-mumps=1 \
+        --download-scalapack=1 \
+        --with-shared-libraries=1 \
+        --with-static-libraries=0 \
+        --with-x=0 \
+        --with-valgrind=0 \
+        --with-mpiexec=/opt/local/bin/mpiexec \
+        --with-debugging=0
+    make PETSC_DIR=/Users/d3g096/Projects/GridPACK/src/petsc-3.20.6 \
+        PETSC_ARCH=mpich-clang-real-shared all
+    make PETSC_DIR=/Users/d3g096/Projects/GridPACK/src/petsc-3.20.6 \
+        PETSC_ARCH=mpich-clang-real-shared install
+
+Building GridPACK
+=================
+
+CMake will work very hard to choose the wrong compiler. Make sure it
+uses the correct compiler by setting environment variables.
+
+Configure, build, and test GridPACK with
+
+    unsetenv DYLD_LIBRARY_PATH
+    setenv CC /opt/local/bin/clang
+    setenv CXX /opt/local/bin/clang++
+    rm -rf CMake*
+    cmake \
+        -D BUILD_GA:BOOL=NO \
+        -D CMAKE_BUILD_TYPE:STRING=Release \
+        -D GA_DIR:PATH=$prefix \
+        -D BOOST_ROOT:STRING=$prefix \
+        -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
+        -D PETSC_DIR:PATH=$prefix \
+        -D MPI_CXX_COMPILER:STRING='/opt/local/bin/mpicxx' \
+        -D MPI_C_COMPILER:STRING='/opt/local/bin/mpicc' \
+        -D MPIEXEC:STRING='/opt/local/bin/mpiexec' \
+        -D MPIEXEC_MAX_NUMPROCS:STRING="2" \
+        -D GRIDPACK_TEST_TIMEOUT:STRING=120 \
+        -D USE_GLPK:BOOL=OFF \
+        -D BUILD_SHARED_LIBS:BOOL=YES \
+        -D CMAKE_INSTALL_PREFIX:PATH=$prefix \
+        -D CMAKE_VERBOSE_MAKEFILE:BOOL=Yes \
+        ..
+    make -j 4
+    ctest
+    make install
+
+GridPACK Python Interface
+=========================
+
+An additional MacPorts package is needed for the Python interface
+
+    sudo port install py312-mpi4py +clang16 +mpich
+    sudo port install py-pip
+    sudo port select --set pip pip312
+    sudo port select --set pip3 pip312
+
+Alternatively, a Python virtual environment can be used to install
+`mpi4py` if desired.
+
+The Python version chosen here is new enough that it does not like to
+run `setup.py` directly, as directed in README.md. So, use `pip` to
+install the module:
+
+    setenv GRIDPACK_DIR $prefix
+    cd .../GridPACK/python
+    pip install --no-deps --upgrade --prefix=$prefix .
+
+This will install the Python module in the same place as the rest of
+GridPACK (`$GRIDPACK_DIR`). To use the module, `PYTHONPATH` must be set.
+In this case, it had to be
+
+    setenv PYTHONPATH $prefix/lib/python3.12/site-packages/
+
+An easy check to see if the module works is
+
+    python -c 'import gridpack'
+
+The first attempt resulted in
+
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+    ImportError: dlopen(/Users/d3g096/Projects/GridPACK/install/lib/python3.12/site-packages/gridpack.cpython-312-darwin.so, 0x0002): Library not loaded: @rpath/libgfortran.5.dylib
+      Referenced from: <B4CFCC4B-7ACE-3880-BA09-FFC95B7F583E> /Users/d3g096/Projects/GridPACK/install/lib/python3.12/site-packages/gridpack.cpython-312-darwin.so
+      Reason: tried: '/Users/d3g096/Projects/GridPACK/install/lib/libgfortran.5.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/d3g096/Projects/GridPACK/install/lib/libgfortran.5.dylib' (no such file), '/Users/d3g096/Projects/GridPACK/install/lib/libgfortran.5.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/d3g096/Projects/GridPACK/install/lib/libgfortran.5.dylib' (no such file)
+
+For some reason, the Fortran shared library could not be found, probably
+something in the PETSc build, so the `DYLD_LIBRARY_PATH` environment
+variable needs to be set
+
+    setenv DYLD_LIBRARY_PATH /opt/local/lib/gcc14
+
+Some complete Python script tests can be found in
+`.../python/src/example`. These exercise the HADREC and dynamic
+simulation applications. Once `PYTHONPATH` and `DYLD_LIBRARY_PATH` are
+set, these should complete without error
+
+    cd src/example
+    python 39bus_test_example.py
+    python 39bus_test_example_dsf.py
+    python 39bus_scatterload_steptest_new_itr.py
+    mpiexec -np 2 python 39bus_scatterload_steptest_new_itr.py
+    python 39bus_scatterload_steptest_new_itr_dsf.py
+    mpiexec -np 2 python 39bus_scatterload_steptest_new_itr_dsf.py
+    python 39bus_scatterload_steptest_new_itr_compensateY.py
+    python 39bus_test_pfdata.py
+

--- a/docs/markdown/platforms/MacOSX.md
+++ b/docs/markdown/platforms/MacOSX.md
@@ -44,6 +44,7 @@ Install the CLang 16.0 compiler set and mpich MPI implementation.
     sudo port install mpich mpich-clang16
     sudo port select --set clang mp-clang-16
     sudo port select --set mpi mpich-clang16-fortran
+    sudo port select gcc mp-gcc14
 
 The latter commands make the installed compilers, and MPI wrappers the
 default. That way the compiler commands, `clang` and `clang++`, and MPI
@@ -61,8 +62,34 @@ Install CMake and other necessities:
     sudo port install cmake
     sudo port install pkgconfig
 
-Build Prerequisites from Source
-===============================
+
+Build GridPACK with Included Scripts
+====================================
+
+The `install_gridpack_deps.sh` and `install_gridpack.sh` scripts
+included in the GridPACK repository can usually simplify the GridPACK
+build process.  On this example system, using the MacPorts packages as
+described above, GridPACK was successfully built using those scripts
+as follows (must be executed within a `bash` shell:
+
+    bash
+    git clone https://github.com/GridOPTICS/GridPACK.git
+    cd GridPACK/
+    export LD_LIBRARY_PATH=/opt/local/lib/gcc14
+    source install_gridpack_deps.sh
+    export CC=/opt/local/bin/clang
+    export CXX=/opt/local/bin/clang++
+    source install_gridpack.sh
+    cd src/build
+    ctest
+    cd applications/dynamic_simulation_full_y
+    ../../../install/bin/dsf2.py input_9b3g.xml
+
+Build from Source
+=================
+
+Prerequisites
+-------------
 
 [PETSc](http://www.mcs.anl.gov/petsc/) and [Global
 Arrays](http://www.emsl.pnl.gov/docs/global/) need to be built from
@@ -80,8 +107,7 @@ variants, will install and is usable to GridPACK. However, PETSc 3.22
 could not be built with SuperLU or Suitesparse. This tends to break some
 solver unit tests. So, build from source.
 
-Global Arrays
--------------
+### Global Arrays ###
 
 GA version 5.8.2 source code was downloaded from the [Github
 site](https://github.com/GlobalArrays/ga/releases/download/v5.8.2/ga-5.8.2.tar.gz).
@@ -106,8 +132,7 @@ GA was configured and built as follows
     make -k check
     make install
 
-Boost
------
+### Boost ###
 
 Boost version 1.81.0 was downloaded from
 [here](https://archives.boost.io/release/1.81.0/source/).
@@ -122,8 +147,7 @@ than a full path.
     ./b2 -a -d+2 toolset=clang link=shared stage
     ./b2 -a -d+2 toolset=clang link=shared install
 
-PETSc
------
+### PETSc ###
 
 On modern Mac OS X, only PETSc version 3.20.1 and later can be used.
 Older versions will not build. This has been noted by others.
@@ -165,7 +189,7 @@ Older versions will not build. This has been noted by others.
         PETSC_ARCH=mpich-clang-real-shared install
 
 Building GridPACK
-=================
+-----------------
 
 CMake will work very hard to choose the wrong compiler. Make sure it
 uses the correct compiler by setting environment variables.
@@ -198,7 +222,7 @@ Configure, build, and test GridPACK with
     make install
 
 GridPACK Python Interface
-=========================
+-------------------------
 
 An additional MacPorts package is needed for the Python interface
 

--- a/docs/markdown/platforms/MacOSX.md
+++ b/docs/markdown/platforms/MacOSX.md
@@ -149,7 +149,7 @@ than a full path.
 
 ### PETSc ###
 
-On modern Mac OS X, only PETSc version 3.20.1 and later can be used.
+On modern Mac OS X, only PETSc version 3.20.1 can be used.
 Older versions will not build. This has been noted by others.
 
     wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.6.tar.gz
@@ -204,8 +204,7 @@ Configure, build, and test GridPACK with
         -D BUILD_GA:BOOL=NO \
         -D CMAKE_BUILD_TYPE:STRING=Release \
         -D GA_DIR:PATH=$prefix \
-        -D BOOST_ROOT:STRING=$prefix \
-        -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
+        -D Boost_ROOT:STRING=$prefix \
         -D PETSC_DIR:PATH=$prefix \
         -D MPI_CXX_COMPILER:STRING='/opt/local/bin/mpicxx' \
         -D MPI_C_COMPILER:STRING='/opt/local/bin/mpicc' \

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -1,6 +1,6 @@
 # This script installs GridPACK and python wrappter.GridPACK is built in src/build directory and installed in src/install directory.
 
-set -xe
+set -x
 
 # This script should be run from the top-level GridPACK directory.
 

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -105,19 +105,22 @@ then
 
     rm -rf build dist gridpack_hadrec.egg-info/
     
-    ${python_exe} pip install --no-deps --upgrade --prefix=$GRIDPACK_INSTALL_DIR .
+    ${python_exe} -m pip install --no-deps --upgrade --prefix=$GRIDPACK_INSTALL_DIR .
 
     # construct the installed package path
 
-    pyvnum=`${python_exe} -V | & sed -e 's/Python  *\([23]\)\.\([0-9][0-9]*\)\..*/\1.\2/' `
-    pydir="${GRIDPACK_DIR}/lib/python${pvnum}/site-packages"
+    pyvnum=`${python_exe} -V | sed -e 's/Python  *\([23]\)\.\([0-9][0-9]*\)\..*/\1.\2/' `
+    pydir="${GRIDPACK_DIR}/lib/python${pyvnum}/site-packages"
     
     if [ -z "$PYTHONPATH" ]; then
         PYTHONPATH="${pydir}:${PYTHONPATH}"
     else
-        PYTHONPATH="${$pydir}"
+        PYTHONPATH="${pydir}"
     fi
     export PYTHONPATH
+
+    # A quick check to see if the Python module is available
+    ${python_exe} -c 'import gridpack
     
 fi
 

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -1,17 +1,24 @@
 # This script installs GridPACK and python wrappter.GridPACK is built in src/build directory and installed in src/install directory.
 
+set -xe
+
 # This script should be run from the top-level GridPACK directory.
 
 # Flag for install GridPACK and GridPACK python wrapper
 install_gridpack=true
-install_gridpack_python=false
+install_gridpack_shared=false
+install_gridpack_python=true
 
-# Set your python executable here
-python_exe=`which python`
-if test -z ${python_exe}
-then
-    python_exe=`which python3`
+if [ "$install_gridpack_python" == "true" ]; then
+    install_gridpack_shared=true
+    # Set your python executable here
+    python_exe=`which python`
+    if test -z ${python_exe}
+    then
+        python_exe=`which python3`
+    fi
 fi
+
 
 if test -z ${GRIDPACK_ROOT_DIR}
 then
@@ -24,6 +31,15 @@ if test -z ${GP_EXT_DEPS}
 then
      export GP_EXT_DEPS=${GRIDPACK_ROOT_DIR}/external-dependencies
 fi
+
+boost_version="1.81.0"
+boost_us_version=`echo $boost_version | sed -e 's/\./_/g'`
+boost_dir="${GP_EXT_DEPS}/boost_${boost_us_version}/install_for_gridpack"
+
+petsc_dir="${GP_EXT_DEPS}/petsc/install_for_gridpack"
+
+ga_version="5.8.2"
+ga_dir="${GP_EXT_DEPS}/ga-${ga_version}/install_for_gridpack"
 
 cd ${GRIDPACK_ROOT_DIR}
 
@@ -50,24 +66,24 @@ then
 
   rm -rf CMake*
 
-  cmake_args="-D GA_DIR:STRING=${GP_EXT_DEPS}/ga-5.8/install_for_gridpack \
-   -D BOOST_ROOT:STRING=${GP_EXT_DEPS}/boost_1_81_0/install_for_gridpack \    
-   -D Boost_DIR:STRING=${GP_EXT_DEPS}/boost_1_81_0/install_for_gridpack/lib/cmake/Boost-1.81.0 \
-   -D Boost_LIBRARIES:STRING=${GP_EXT_DEPS}/boost_1_81_0/install_for_gridpack/lib \   
-   -D Boost_INCLUDE_DIRS:STRING=${GP_EXT_DEPS}/boost_1_81_0/install_for_gridpack/include \
-   -D PETSC_DIR:PATH=${GP_EXT_DEPS}/petsc/install_for_gridpack \                  
-   -D MPI_CXX_COMPILER:STRING='mpicxx' \     
-   -D MPI_C_COMPILER:STRING='mpicc' \                                         
-   -D MPIEXEC:STRING='mpiexec' \                                                            
-   -D GRIDPACK_TEST_TIMEOUT:STRING=30 \                                                     
-   -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_INSTALL_DIR} \             
-   -D CMAKE_BUILD_TYPE:STRING=Debug \
-   -D BUILD_SHARED_LIBS=NO \
-   -D CMAKE_CXX_FLAGS="-std=c++0x" \
-   -D Boost_NO_SYSTEM_PATHS:BOOL=TRUE \
+  cmake_args="-D GA_DIR:STRING=${ga_dir}
+   -D BOOST_ROOT:STRING=$boost_dir 
+   -D Boost_DIR:STRING=$boost_dir 
+   -D Boost_LIBRARIES:STRING=${boost_dir}/lib 
+   -D Boost_INCLUDE_DIRS:STRING=${boost_dir}/include 
+   -D Boost_NO_BOOST_CMAKE:BOOL=TRUE 
+   -D Boost_NO_SYSTEM_PATHS:BOOL=TRUE 
+   -D PETSC_DIR:PATH=${petsc_dir} 
+   -D MPI_CXX_COMPILER:STRING='mpicxx' 
+   -D MPI_C_COMPILER:STRING='mpicc' 
+   -D MPIEXEC:STRING='mpiexec' 
+   -D GRIDPACK_TEST_TIMEOUT:STRING=120 
+   -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_INSTALL_DIR} 
+   -D CMAKE_BUILD_TYPE:STRING=Debug 
+   -D BUILD_SHARED_LIBS=$install_gridpack_shared 
     ..   "
  
-  cmake ${cmake_args}                                                                                     
+  cmake -Wdev ${cmake_args}                                                                                     
 
    echo "Installing GridPACK develop branch"
    make -j 10 install
@@ -84,18 +100,19 @@ then
     echo ${GRIDPACK_DIR}
     cd python
 
-    export RHEL_OPENMPI_HACK=yes
+    # This is necessary on RHEL/CentOS systems
+    # export RHEL_OPENMPI_HACK=yes
 
-    rm -rf build
+    rm -rf build dist gridpack_hadrec.egg-info/
     
-    ${python_exe} setup.py build
+    pip install --no-deps --upgrade --prefix=$GRIDPACK_INSTALL_DIR .
 
-    rm -rf ${GRIDPACK_INSTALL_DIR}/lib/python
-    mkdir ${GRIDPACK_INSTALL_DIR}/lib/python
-    
-    PYTHONPATH="${GRIDPACK_DIR}/lib/python:${PYTHONPATH}"
+    if [ -z "$PYTHONPATH" ]; then
+        PYTHONPATH="${GRIDPACK_DIR}/lib/python:${PYTHONPATH}"
+    else
+        PYTHONPATH="${GRIDPACK_DIR}/lib/python"
+    fi
     export PYTHONPATH
-    ${python_exe} setup.py install --home="$GRIDPACK_DIR"
     
 fi
 

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -132,3 +132,5 @@ fi
 cd ${GRIDPACK_ROOT_DIR}
 
 echo "Completed GridPACK installation"
+
+set +x

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -13,7 +13,7 @@ install_gridpack_python=true
 boost_version="1.81.0"
 ga_version="5.8.2"
 
-if [ "$install_gridpack_python" == "true" ]; then
+if "$install_gridpack_python"; then
     install_gridpack_shared=true
     # Set your python executable here
     python_exe=`which python`
@@ -79,6 +79,7 @@ then
    -D MPI_CXX_COMPILER:STRING='mpicxx' 
    -D MPI_C_COMPILER:STRING='mpicc' 
    -D MPIEXEC:STRING='mpiexec' 
+   -D MPIEXEC_MAX_NUMPROCS:STRING=2
    -D GRIDPACK_TEST_TIMEOUT:STRING=120 
    -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_INSTALL_DIR} 
    -D CMAKE_BUILD_TYPE:STRING=Debug 
@@ -109,10 +110,12 @@ then
     
     ${python_exe} -m pip install --no-deps --upgrade --prefix=$GRIDPACK_INSTALL_DIR .
 
-    # construct the installed package path
+    # Construct the installed package path and check it. The actual
+    # path with in the prefix seems to be kind of random, so
+    # add a couple of options to PYTHONPATH
 
     pyvnum=`${python_exe} -V | sed -e 's/Python  *\([23]\)\.\([0-9][0-9]*\)\..*/\1.\2/' `
-    pydir="${GRIDPACK_DIR}/lib/python${pyvnum}/site-packages"
+    pydir="${GRIDPACK_DIR}/lib/python${pyvnum}/site-packages:${GRIDPACK_DIR}/local/lib/python${pyvnum}/dist-packages"
     
     if [ -z "$PYTHONPATH" ]; then
         PYTHONPATH="${pydir}:${PYTHONPATH}"

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -9,6 +9,10 @@ install_gridpack=true
 install_gridpack_shared=false
 install_gridpack_python=true
 
+# These must match install_gridpack_deps.sh
+boost_version="1.81.0"
+ga_version="5.8.2"
+
 if [ "$install_gridpack_python" == "true" ]; then
     install_gridpack_shared=true
     # Set your python executable here
@@ -32,13 +36,11 @@ then
      export GP_EXT_DEPS=${GRIDPACK_ROOT_DIR}/external-dependencies
 fi
 
-boost_version="1.81.0"
 boost_us_version=`echo $boost_version | sed -e 's/\./_/g'`
 boost_dir="${GP_EXT_DEPS}/boost_${boost_us_version}/install_for_gridpack"
 
 petsc_dir="${GP_EXT_DEPS}/petsc/install_for_gridpack"
 
-ga_version="5.8.2"
 ga_dir="${GP_EXT_DEPS}/ga-${ga_version}/install_for_gridpack"
 
 cd ${GRIDPACK_ROOT_DIR}
@@ -120,7 +122,7 @@ then
     export PYTHONPATH
 
     # A quick check to see if the Python module is available
-    ${python_exe} -c 'import gridpack
+    ${python_exe} -c 'import gridpack'
     
 fi
 

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -105,12 +105,17 @@ then
 
     rm -rf build dist gridpack_hadrec.egg-info/
     
-    pip install --no-deps --upgrade --prefix=$GRIDPACK_INSTALL_DIR .
+    ${python_exe} pip install --no-deps --upgrade --prefix=$GRIDPACK_INSTALL_DIR .
 
+    # construct the installed package path
+
+    pyvnum=`${python_exe} -V | & sed -e 's/Python  *\([23]\)\.\([0-9][0-9]*\)\..*/\1.\2/' `
+    pydir="${GRIDPACK_DIR}/lib/python${pvnum}/site-packages"
+    
     if [ -z "$PYTHONPATH" ]; then
-        PYTHONPATH="${GRIDPACK_DIR}/lib/python:${PYTHONPATH}"
+        PYTHONPATH="${pydir}:${PYTHONPATH}"
     else
-        PYTHONPATH="${GRIDPACK_DIR}/lib/python"
+        PYTHONPATH="${$pydir}"
     fi
     export PYTHONPATH
     

--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -69,12 +69,7 @@ then
   rm -rf CMake*
 
   cmake_args="-D GA_DIR:STRING=${ga_dir}
-   -D BOOST_ROOT:STRING=$boost_dir 
-   -D Boost_DIR:STRING=$boost_dir 
-   -D Boost_LIBRARIES:STRING=${boost_dir}/lib 
-   -D Boost_INCLUDE_DIRS:STRING=${boost_dir}/include 
-   -D Boost_NO_BOOST_CMAKE:BOOL=TRUE 
-   -D Boost_NO_SYSTEM_PATHS:BOOL=TRUE 
+   -D Boost_ROOT:STRING=$boost_dir
    -D PETSC_DIR:PATH=${petsc_dir} 
    -D MPI_CXX_COMPILER:STRING='mpicxx' 
    -D MPI_C_COMPILER:STRING='mpicc' 

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -45,7 +45,7 @@ then
   boost_version="1.81.0"
   boost_us_version=`echo $boost_version | sed -e 's/\./_/g'`
 
-  if [ "$install_shared" == "true" ]; then
+  if "$install_shared"; then
       boostshared="shared"
   else
       boostshared="static"
@@ -84,7 +84,7 @@ then
   # Download, build, and install GA
   cd ${GP_EXT_DEPS}
 
-  if [ "$install_shared" == "true" ]; then
+  if "$install_shared"; then
       gashopts="--enable-shared=yes --enable-static=no"
   else
       gashopts="--enable-shared=no --enable-static=yes"
@@ -118,7 +118,7 @@ fi
 if ${install_petsc}
 then
 
-  if [ "$install_shared" == "true" ]; then
+  if "$install_shared"; then
       petscopts="--with-shared-libraries=1"
   else
       petscopts="--with-shared-libraries=0"
@@ -126,6 +126,7 @@ then
 
   # petsc_version="3.21.4"
   petsc_version="3.20.6"
+  # petsc_version="3.19.4"
     
   # Install PETSc 
   cd ${GP_EXT_DEPS}
@@ -149,7 +150,20 @@ then
   # Install PETSc
   echo "Installing PETSc $petsc_version"
     
-  ./configure --with-fortran-bindings=0 --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake=0 --prefix=${PWD}/install_for_gridpack --scalar-type=complex  --download-scalapack --download-mumps --with-sowing=0 --download-f2cblaslapack $petscopts
+  ./configure \
+      --prefix=${PWD}/install_for_gridpack \
+      --scalar-type=complex  \
+      --with-fortran-bindings=0 \
+      --download-superlu_dist \
+      --download-metis \
+      --download-parmetis \
+      --download-suitesparse \
+      --download-f2cblaslapack \
+      --download-scalapack \
+      --download-mumps \
+      --download-cmake=0 \
+      --with-sowing=0 \
+      $petscopts
 
   # Build PETSc
   echo "Building PETSc $petsc_version"

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -1,5 +1,5 @@
 
-set -xe
+set -x
 
 # This script installs all GridPACK dependencies.The dependencies are installed in external-dependencies directory.
 

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -1,3 +1,6 @@
+
+set -xe
+
 # This script installs all GridPACK dependencies.The dependencies are installed in external-dependencies directory.
 
 # This script should be run from the top-level GridPACK directory.
@@ -6,6 +9,7 @@
 install_boost=true
 install_ga=true
 install_petsc=true
+install_shared=true
 
 echo $(date)
 
@@ -38,30 +42,39 @@ cd ${GP_EXT_DEPS}
 if ${install_boost}
 then
 
+  boost_version="1.81.0"
+  boost_us_version=`echo $boost_version | sed -e 's/\./_/g'`
+
+  if [ "$install_shared" == "true" ]; then
+      boostshared="shared"
+  else
+      boostshared="static"
+  fi
+
   rm -rf boost*
     
   # Download and install Boost
-  echo "Downloading Boost-1.81.0"
+  echo "Downloading Boost-$boost_version"
 
-  # Download Boost
-  wget https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz
+    # Download Boost
+  wget https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_us_version}.tar.gz
 
   # Untar
-  tar -xf boost_1_81_0.tar.gz
+  tar -xf boost_${boost_us_version}.tar.gz
 
-  cd boost_1_81_0
+  cd boost_${boost_us_version}
 
   # Install boost
-  echo "Building Boost-1.81.0"
+  echo "Building Boost-${boost_version}"
 
   ./bootstrap.sh --prefix=install_for_gridpack --with-libraries=mpi,serialization,random,filesystem,system
 
-  echo 'using mpi ;' >> project-config.jam
+  echo 'using mpi : mpicxx ; ' >> project-config.jam
+  
+  ./b2 -a -d+2 link="$boostshared" stage 
 
-  ./b2 -a -d+2 link=static stage
-
-  echo "Installing Boost-1.78.0"
-  ./b2 -a -d+2 link=static install
+  echo "Installing Boost-$boost_version"
+  ./b2 -a -d+2 link="$boostshared" install
 
   echo "Building and Installing Boost libraries complete"
 fi
@@ -71,66 +84,87 @@ then
   # Download, build, and install GA
   cd ${GP_EXT_DEPS}
 
-  rm -rf ga*
+  if [ "$install_shared" == "true" ]; then
+      gashopts="--enable-shared=yes --enable-static=no"
+  else
+      gashopts="--enable-shared=no --enable-static=yes"
+  fi
 
-  echo "Downloading GA-5.8"
+  gaversion="5.8.2"
+  echo "Downloading GA-$gaversion"
 
-  wget https://github.com/GlobalArrays/ga/releases/download/v5.8/ga-5.8.tar.gz
+  wget "https://github.com/GlobalArrays/ga/releases/download/v${gaversion}/ga-${gaversion}.tar.gz"
 
-  tar -xf ga-5.8.tar.gz
+  tar -xf "ga-${gaversion}.tar.gz"
 
-  cd ga-5.8
+  cd ga-${gaversion}
 
   # Build GA
-  echo "Building GA-5.8"
-  ./configure --with-mpi-ts --disable-f77 --without-blas --enable-cxx --enable-i4 --prefix=${PWD}/install_for_gridpack
+  echo "Building GA-${gaversion}"
+  ./configure --with-mpi-ts --disable-f77 \
+              --without-blas --without-lapack --without-scalapack \
+              --enable-cxx --enable-i4 \
+              --prefix=${PWD}/install_for_gridpack \
+              CFLAGS=-Wno-implicit-function-declaration \
+              $gashopts
   
   # Install GA
-  echo "Installing GA-5.8"
+  echo "Installing GA-${gaversion}"
   make -j 10 install
   
-  echo "GA-5.8 installation complete"
+  echo "GA-${gaversion} installation complete"
 fi
 
 if ${install_petsc}
 then
+
+  if [ "$install_shared" == "true" ]; then
+      petscopts="--with-shared-libraries=1"
+  else
+      petscopts="--with-shared-libraries=0"
+  fi
+
+  # petsc_version="3.21.4"
+  petsc_version="3.20.6"
     
-  # Install PETSc 3.20.1
+  # Install PETSc 
   cd ${GP_EXT_DEPS}
 
   rm -rf petsc*
   
   # Download
-  echo "Downloading PETSc"
+  echo "Downloading PETSc $petsc_version"
 
   git clone https://gitlab.com/petsc/petsc.git
     
   cd petsc
 
-  git checkout tags/v3.20.1 -b v3.20.1
+  # git checkout tags/v3.16.4 -b v3.16.4
+  git checkout "tags/v$petsc_version" -b "v$petsc_version"
 
   export PETSC_DIR=${PWD}
   export PETSC_ARCH=build-dir
+  rm -rf $PETSC_ARCH
 
   # Install PETSc
-  echo "Installing PETSc 3.20.1"
+  echo "Installing PETSc $petsc_version"
     
-  ./configure --download-superlu_dist --download-metis --download-parmetis --with-debugging=0 --prefix=${PWD}/install_for_gridpack
+  ./configure --with-gnu-compilers=0 --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake=0 --prefix=${PWD}/install_for_gridpack --scalar-type=complex  --download-sowing  --download-f2cblaslapack $petscopts
 
   # Build PETSc
-  echo "Building PETSc 3.20.1"
+  echo "Building PETSc $petsc_version"
 
   make 
 
   # Install PETSc
-  echo "Installing PETSc 3.20.1"
+  echo "Installing PETSc $petsc_version"
 
   make install
   make check  
 fi  
 
 # update LD_LIBRARY_PATH so that boost,ga, and petsc are on it
-export LD_LIBRARY_PATH=${GP_EXT_DEPS}/boost_1_81_0/install_for_gridpack/lib:${GP_EXT_DEPS}/ga-5.8/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${GP_EXT_DEPS}/boost_${boost_us_version}/install_for_gridpack/lib:${GP_EXT_DEPS}/${gaversion}/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib:${LD_LIBRARY_PATH}
 
 cd ${GRIDPACK_ROOT_DIR}
 

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -56,8 +56,10 @@ then
   # Download and install Boost
   echo "Downloading Boost-$boost_version"
 
-    # Download Boost
-  wget https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_us_version}.tar.gz
+  # Download Boost
+  # wget https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_us_version}.tar.gz
+
+  wget "https://pilotfiber.dl.sourceforge.net/project/boost/boost/${boost_version}/boost_${boost_us_version}.tar.gz"
 
   # Untar
   tar -xf boost_${boost_us_version}.tar.gz

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -90,17 +90,17 @@ then
       gashopts="--enable-shared=no --enable-static=yes"
   fi
 
-  gaversion="5.8.2"
-  echo "Downloading GA-$gaversion"
+  ga_version="5.8.2"
+  echo "Downloading GA-$ga_version"
 
-  wget "https://github.com/GlobalArrays/ga/releases/download/v${gaversion}/ga-${gaversion}.tar.gz"
+  wget "https://github.com/GlobalArrays/ga/releases/download/v${ga_version}/ga-${ga_version}.tar.gz"
 
-  tar -xf "ga-${gaversion}.tar.gz"
+  tar -xf "ga-${ga_version}.tar.gz"
 
-  cd ga-${gaversion}
+  cd ga-${ga_version}
 
   # Build GA
-  echo "Building GA-${gaversion}"
+  echo "Building GA-${ga_version}"
   ./configure --with-mpi-ts --disable-f77 \
               --without-blas --without-lapack --without-scalapack \
               --enable-cxx --enable-i4 \
@@ -109,10 +109,10 @@ then
               $gashopts
   
   # Install GA
-  echo "Installing GA-${gaversion}"
+  echo "Installing GA-${ga_version}"
   make -j 10 install
   
-  echo "GA-${gaversion} installation complete"
+  echo "GA-${ga_version} installation complete"
 fi
 
 if ${install_petsc}
@@ -149,7 +149,7 @@ then
   # Install PETSc
   echo "Installing PETSc $petsc_version"
     
-  ./configure --with-gnu-compilers=0 --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake=0 --prefix=${PWD}/install_for_gridpack --scalar-type=complex  --download-sowing  --download-f2cblaslapack $petscopts
+  ./configure --with-fortran-bindings=0 --download-superlu_dist --download-metis --download-parmetis --download-suitesparse --download-f2cblaslapack --download-cmake=0 --prefix=${PWD}/install_for_gridpack --scalar-type=complex  --download-scalapack --download-mumps --with-sowing=0 --download-f2cblaslapack $petscopts
 
   # Build PETSc
   echo "Building PETSc $petsc_version"
@@ -164,7 +164,10 @@ then
 fi  
 
 # update LD_LIBRARY_PATH so that boost,ga, and petsc are on it
-export LD_LIBRARY_PATH=${GP_EXT_DEPS}/boost_${boost_us_version}/install_for_gridpack/lib:${GP_EXT_DEPS}/${gaversion}/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${GP_EXT_DEPS}/boost_${boost_us_version}/install_for_gridpack/lib:${GP_EXT_DEPS}/${ga_version}/install_for_gridpack/lib:${GP_EXT_DEPS}/petsc/install_for_gridpack/lib:${LD_LIBRARY_PATH}
+
+# For Mac OS X
+export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 cd ${GRIDPACK_ROOT_DIR}
 

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -186,3 +186,5 @@ export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 cd ${GRIDPACK_ROOT_DIR}
 
 echo "Completed installing GridPACK dependencies in ${GP_EXT_DEPS}"
+
+set +x

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -152,7 +152,7 @@ then
     
   ./configure \
       --prefix=${PWD}/install_for_gridpack \
-      --scalar-type=complex  \
+      --scalar-type=real  \
       --with-fortran-bindings=0 \
       --download-superlu_dist \
       --download-metis \

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 project(gridpack-hadrec)
 
 if (DEFINED ENV{RHEL_OPENMPI_HACK})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,6 +5,13 @@ if (DEFINED ENV{RHEL_OPENMPI_HACK})
   add_definitions (-DRHEL_OPENMPI_HACK=1)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(CMAKE_MACOSX_RPATH 1)
+endif()
+set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 # -------------------------------------------------------------
 # Python
 # -------------------------------------------------------------
@@ -75,6 +82,8 @@ endif()
 include("${GRIDPACK_DIR}/lib/GridPACK.cmake")
 
 gridpack_setup()
+
+list( APPEND CMAKE_INSTALL_RPATH ${GRIDPACK_LIB} )
 
 add_definitions(${GRIDPACK_DEFINITIONS})
 include_directories(BEFORE ${GRIDPACK_INCLUDE_DIRS})

--- a/python/README.md
+++ b/python/README.md
@@ -53,9 +53,14 @@ RHEL_OPENMPI_HACK=yes
 export RHEL_OPENMPI_HACK
 ```
 
-This seems to be necessary on constance.
+This seems to be necessary on constance. 
+
+It is *not* necessary with MPICH or apparently OpenMPI on other Linux
+distributions.  
 
 ### Build
+
+*This is deprecated, but may still work with older Pythons.*
 
 In the top directory (where `setup.py` is),
 ```
@@ -63,6 +68,9 @@ python setup.py build
 ```
 
 ### Test
+
+*This is deprecated, but may still work with older Pythons.*
+
 Again, in the top directory,
 ```
 python setup.py test
@@ -83,6 +91,35 @@ OK
 
 ## Installation 
 
+With modern versions of Python and setuptools, it's best to use `pip`
+to install the module:
+```
+setenv GRIDPACK_DIR $prefix
+cd .../GridPACK/python
+pip install --no-deps --upgrade --prefix=$GRIDPACK_DIR .
+```
+This will install the Python module in the same place as the rest of
+GridPACK (`$GRIDPACK_DIR`).  To use the module, `PYTHONPATH` must be
+set to the site packages directory under `$GRIDPACK_DIR`. The path
+will depend on the Python version used.  For example, 
+```
+setenv PYTHONPATH $GRIDPACK_DIR/lib/python3.12/site-packages/
+```
+or
+```
+export PYTHONPATH=$GRIDPACK_DIR/lib/python3.12/site-packages
+```
+Alternatively, a Python virtual environment can be used.  
+
+An easy check to see if the module works is
+```
+python -c 'import gridpack'
+```
+
+*The below deprecated, but may still work with older Python
+installations. If this is used with newer Python versions, the module
+will not be installed correctly and be unusable.  *
+
 In order to use the wrapper it needs to be installed in a way Python
 can use it.  However, you shouldn't (and probably cannot) install the
 module in the system python library.  So, choose a place to install it. I would
@@ -101,14 +138,34 @@ This seems to be the way on Linux systems.
 This installs the Python module and a Python version of the HADREC
 application, `${GRIDPACK_DIR}/bin/hadrec.py`.
 
-## Run Example
+## Run Examples
 
 Once installed, with `PYTHONPATH` set correctly, the Python version of
-the HADREC application can be run
+several GridPACK applications can be run.  In
+`.../python/src/example` are a number of custom Python scripts that
+can be run to insure the viability of the GridPACK Python
+interface:
+```
+cd src/example
+python 39bus_test_example.py
+python 39bus_test_example_dsf.py
+python 39bus_scatterload_steptest_new_itr.py
+mpiexec -np 2 python 39bus_scatterload_steptest_new_itr.py
+python 39bus_scatterload_steptest_new_itr_dsf.py
+mpiexec -np 2 python 39bus_scatterload_steptest_new_itr_dsf.py
+python 39bus_scatterload_steptest_new_itr_compensateY.py
+python 39bus_test_pfdata.py
+```
+Dynamic simulation examples can also be run.
+`$GRIDPACK_DIR/bin/dsf2.py` behaves identically to
+`$GRIDPACK_DIR/bin/dsf2.x` and can run any of the example simulations
+in `.../src/build/applications/dynamic_simulation_full_y`, for example
 
 ```
-cd src/tests
-python ${GRIDPACK_DIR}/bin/hadrec.py input_tamu500_step005.xml
+cd ../src/build/applications/dynamic_simulation_full_y
+$GRIDPACK_DIR/bin/dsf2.py input_9b3g.xml
+$GRIDPACK_DIR/bin/dsf2.py input_240bus.xml
+mpiexec -np 4 $GRIDPACK_DIR/bin/dsf2.py input_240bus.xml
 ```
 
 ## Running on Constance

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,10 +247,15 @@ endif()
 
 option(BOOST_BUILD_PYTHON "Include Boost::Python in the Boost build" OFF)
 
+# Use the old way to find Boost
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+
 # These are the Boost libraries required here
   
 set(BOOST_BUILD_LIBS "")
-list(APPEND BOOST_BUILD_LIBS mpi serialization random filesystem system)
+list(APPEND BOOST_BUILD_LIBS mpi serialization random system)
 
 if(BUILD_BOOST)
 
@@ -265,9 +270,9 @@ if(BUILD_BOOST)
   list(APPEND GRIDPACK_TEST_LDPATH ${Boost_LIBRARY_DIR_DEBUG} ${Boost_LIBRARY_DIR_RELEASE} )
 else(BUILD_BOOST)
   message(STATUS "Checking Boost ...")
-  find_package(Boost 1.53
+  find_package(Boost 1.70
     COMPONENTS ${BOOST_BUILD_LIBS}
-    REQUIRED
+    REQUIRED CONFIG
     )
 endif(BUILD_BOOST)
 message(STATUS "Boost_INCLUDE_DIRS=${Boost_INCLUDE_DIRS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 
 # 
-cmake_minimum_required (VERSION 3.5.0)
+cmake_minimum_required (VERSION 3.22)
 
 project (GridPACK)
 

--- a/src/applications/modules/emt/CMakeLists.txt
+++ b/src/applications/modules/emt/CMakeLists.txt
@@ -17,13 +17,9 @@ endif()
 
 set(target_libraries
     ${target_libraries}	
+    gridpack_powerflow_module
     gridpack_ymatrix_components
-    gridpack_components
     gridpack_partition
-    gridpack_parallel
-    gridpack_math
-    gridpack_configuration
-    gridpack_timer
     ${PARMETIS_LIBRARY} ${METIS_LIBRARY} 
     ${Boost_LIBRARIES}
     ${GA_LIBRARIES}

--- a/src/applications/modules/kalman_ds/CMakeLists.txt
+++ b/src/applications/modules/kalman_ds/CMakeLists.txt
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
-# Last Change: 2022-10-05 08:17:42 d3g096
+# Last Change: 2024-08-20 07:11:49 d3g096
 # -------------------------------------------------------------
 
 set(target_libraries
@@ -44,7 +44,7 @@ gridpack_set_library_version(gridpack_kalmands_module)
 target_link_libraries(gridpack_kalmands_module
   gridpack_kdsmatrix_components
   gridpack_partition
-  gridpack_stream
+  gridpack_block_parsers
   )
 
 # -------------------------------------------------------------

--- a/src/applications/modules/powerflow/CMakeLists.txt
+++ b/src/applications/modules/powerflow/CMakeLists.txt
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
-# Last Change: 2022-10-05 08:18:54 d3g096
+# Last Change: 2024-08-09 05:55:30 d3g096
 # -------------------------------------------------------------
 
 set(target_libraries
@@ -45,6 +45,7 @@ gridpack_set_library_version(gridpack_powerflow_module)
 target_link_libraries(gridpack_powerflow_module
   gridpack_pfmatrix_components
   gridpack_partition
+  gridpack_block_parsers
   gridpack_stream
   )
 

--- a/src/applications/modules/state_estimation/CMakeLists.txt
+++ b/src/applications/modules/state_estimation/CMakeLists.txt
@@ -41,7 +41,7 @@ gridpack_set_library_version(gridpack_state_estimation_module)
 target_link_libraries(gridpack_state_estimation_module
   gridpack_sematrix_components
   gridpack_partition
-  gridpack_stream
+  gridpack_block_parsers
   )
 
 # -------------------------------------------------------------

--- a/src/cmake-modules/GridPACK.cmake
+++ b/src/cmake-modules/GridPACK.cmake
@@ -99,7 +99,7 @@ function(gridpack_add_parallel_unit_test test_name test_target)
       FAIL_REGULAR_EXPRESSION "failure detected"
       TIMEOUT ${GRIDPACK_TEST_TIMEOUT}
       # MPIEXEC will not look for executables in the current directory sometimes
-      ENVIRONMENT "PATH=./:%PATH%"
+      ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:./"
       )
     set_tests_ldpath("${the_test_name}")
   else() 
@@ -123,7 +123,7 @@ function(gridpack_add_parallel_run_test test_name test_target test_input)
       PROPERTIES 
       TIMEOUT ${GRIDPACK_TEST_TIMEOUT}
       # MPIEXEC will not look for executables in the current directory sometimes
-      ENVIRONMENT "PATH=./:%PATH%"
+      ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:./"
       )
     set_tests_ldpath("${the_test_name}")
   else()

--- a/src/cmake-modules/GridPACK.cmake
+++ b/src/cmake-modules/GridPACK.cmake
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created June 10, 2013 by William A. Perkins
-# Last Change: 2023-12-13 07:00:00 d3g096
+# Last Change: 2024-11-21 07:59:56 d3g096
 # -------------------------------------------------------------
 
 
@@ -99,6 +99,8 @@ function(gridpack_add_parallel_unit_test test_name test_target)
       PASS_REGULAR_EXPRESSION "No errors detected"
       FAIL_REGULAR_EXPRESSION "failure detected"
       TIMEOUT ${GRIDPACK_TEST_TIMEOUT}
+      # MPIEXEC will not look for executables in the current directory sometimes
+      ENVIRONMENT "PATH=./:%PATH%"
       )
     set_tests_ldpath("${the_test_name}")
   else() 

--- a/src/cmake-modules/GridPACK.cmake
+++ b/src/cmake-modules/GridPACK.cmake
@@ -10,7 +10,6 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created June 10, 2013 by William A. Perkins
-# Last Change: 2024-11-21 07:59:56 d3g096
 # -------------------------------------------------------------
 
 
@@ -123,6 +122,8 @@ function(gridpack_add_parallel_run_test test_name test_target test_input)
     set_tests_properties("${the_test_name}"
       PROPERTIES 
       TIMEOUT ${GRIDPACK_TEST_TIMEOUT}
+      # MPIEXEC will not look for executables in the current directory sometimes
+      ENVIRONMENT "PATH=./:%PATH%"
       )
     set_tests_ldpath("${the_test_name}")
   else()

--- a/src/configuration/test/configuration_test.cpp
+++ b/src/configuration/test/configuration_test.cpp
@@ -6,7 +6,7 @@
 /**
  * @file   configuration_test.cpp
  * @author William A. Perkins
- * @date   2017-01-10 07:59:05 d3g096
+ * @date   2024-08-20 06:36:13 d3g096
  * 
  * @brief  A test of Configurable and Configuration
  * 
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <boost/lexical_cast.hpp>
 
 #define BOOST_TEST_NO_MAIN
@@ -74,7 +75,7 @@ protected:
 
 BOOST_AUTO_TEST_CASE( Configurable )
 {
-  std::auto_ptr<gridpack::utility::Configuration> 
+  std::unique_ptr<gridpack::utility::Configuration> 
     config(gridpack::utility::Configuration::configuration());
 
   BOOST_REQUIRE(config.get() != NULL);
@@ -84,7 +85,7 @@ BOOST_AUTO_TEST_CASE( Configurable )
 
   BOOST_REQUIRE(cursor != NULL);
 
-  std::auto_ptr<ConfigurableThing> thing(new ConfigurableThing);
+  std::unique_ptr<ConfigurableThing> thing(new ConfigurableThing);
 
   thing->configure(cursor);
 

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -252,8 +252,7 @@ elif [ $host == "tlaloc" ]; then
         --graphviz=GridPACK.dot \
           -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.21.6" \
           -D PETSC_ARCH:STRING="ubuntu-real-shared-debug" \
-          -D BOOST_ROOT:PATH="/usr" \
-          -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
+          -D Boost_ROOT:PATH="/usr" \
           -D PARMETIS_DIR:PATH="/usr" \
           -D MPI_CXX_COMPILER:STRING="mpicxx" \
           -D MPI_C_COMPILER:STRING="mpicc" \

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -118,9 +118,9 @@ elif [ $host == "WE39945" ]; then
     #   sudo port select clang mp-clang-6.0
     # Cannot use PETSc < 3.20.0
 
-    CC=/opt/local/bin/clang
+    CC=gcc
     export CC
-    CXX=/opt/local/bin/clang++
+    CXX=g++
     export CC CXX 
 
     prefix="$HOME/Projects/GridPACK/install"
@@ -128,9 +128,10 @@ elif [ $host == "WE39945" ]; then
     cmake $options \
         --graphviz=GridPACK.dot \
         -D GA_DIR:STRING="$prefix" \
-        -D BOOST_ROOT:STRING="$prefix" \
+        -D Boost_ROOT:STRING="$prefix" \
         -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
-        -D PETSC_DIR:PATH="$prefix" \
+        -D PETSC_DIR:PATH="/Users/d3g096/Projects/GridPACK/src/petsc-3.20.6" \
+        -D PETSC_ARCH:STRING="mpich-clang-real-shared" \
         -D MPI_CXX_COMPILER:STRING='/opt/local/bin/mpicxx' \
         -D MPI_C_COMPILER:STRING='/opt/local/bin/mpicc' \
         -D MPIEXEC:STRING='/opt/local/bin/mpiexec' \

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -104,51 +104,39 @@ if [ $host == "briareus" ]; then
         -D CMAKE_INSTALL_PREFIX:PATH="$prefix" \
         $common_flags ..
 
-elif [ $host == "we32673" ]; then
+elif [ $host == "WE39945" ]; then
 
-    # Mac using CLang 14.0 compilers and MPICH via MacPorts
+    # Macbook Pro using CLang 16.0 compilers and MPICH via MacPorts
     # The following MacPorts packages are installed:
-    #   clang-14 @14.0.6_0+analyzer+libstdcxx
-    #   mpich-clang14 @4.0.2_0+gcc12
-    #   boost176 @1.76.0_3+clang14+mpich+no_single+no_static+python310
+    #   clang-16 @16.0.6_6+analyzer
+    #   mpich-clang16 @4.2.3_0+gcc14
     # Global Arrays 5.7 built by hand
     # PETSc 3.8.4 w/ ParMETIS, SuperLU, etc., built by hand
+    # Boost 1.81 w/ MPI build by hand
     # Need to make sure the compiler set and MPI are selected, i.e.
+    #   sudo port select --set mpi mpich-clang16-fortran
     #   sudo port select clang mp-clang-6.0
-    #   sudo port select mpi mpich-clang60-fortran
-    # Cannot use PETSc < 3.8.0
+    # Cannot use PETSc < 3.20.0
 
     CC=/opt/local/bin/clang
     export CC
     CXX=/opt/local/bin/clang++
     export CC CXX 
 
-    prefix="/Users/d3g096/Projects/GridPACK"
-    pdir="$prefix/petsc.gitlab"
+    prefix="$HOME/Projects/GridPACK/install"
 
-    if [ "$shared"x = "ON"x ]; then
-        parch="darwin-mpich-clang-real-opt-3.16"
-        parch="darwin-mpich-clang-complex-opt-3.16"
-    else
-        parch="darwin-mpich-clang-complex-opt-3.16-static"
-    fi
-    
     cmake $options \
         --graphviz=GridPACK.dot \
-        -D GA_DIR:STRING="$prefix/gridpack-install" \
-        -D BOOST_ROOT:STRING="/opt/local/libexec/boost/1.76" \
+        -D GA_DIR:STRING="$prefix" \
+        -D BOOST_ROOT:STRING="$prefix" \
         -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
-        -D PETSC_DIR:PATH="$pdir" \
-        -D PETSC_ARCH:STRING="$parch" \
+        -D PETSC_DIR:PATH="$prefix" \
         -D MPI_CXX_COMPILER:STRING='/opt/local/bin/mpicxx' \
         -D MPI_C_COMPILER:STRING='/opt/local/bin/mpicc' \
         -D MPIEXEC:STRING='/opt/local/bin/mpiexec' \
         -D MPIEXEC_MAX_NUMPROCS:STRING="2" \
-        -D GRIDPACK_TEST_TIMEOUT:STRING=60 \
-        -D USE_CPLEX:BOOL=OFF \
-        -D USE_GLPK:BOOL=ON \
-        -D GLPK_ROOT_DIR:PATH="/opt/local" \
-        -D CMAKE_INSTALL_PREFIX:PATH="$prefix/gridpack-install" \
+        -D GRIDPACK_TEST_TIMEOUT:STRING=120 \
+        -D CMAKE_INSTALL_PREFIX:PATH="$prefix" \
         $common_flags ..
 
 elif [ $host == "constance" ]; then

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -231,7 +231,15 @@ elif [ $host == "tlaloc" ]; then
     # Custom built 3.20, real:
     #      -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.20.6" \
     #      -D PETSC_ARCH:STRING="ubuntu-real-shared" \
-    
+
+    # Custom built 3.21, complex:
+    #      -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.21.6" \
+    #      -D PETSC_ARCH:STRING="ubuntu-complex-shared-debug" \
+
+    # Custom built 3.21, complex:
+    #      -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.21.6" \
+    #      -D PETSC_ARCH:STRING="ubuntu-real-shared-debug" \
+
     if [ -z "$GRIDPACK_DIR" ]; then
         prefix="$HOME/Projects/ExaLearn/gridpack-install"
     else
@@ -241,8 +249,8 @@ elif [ $host == "tlaloc" ]; then
     prefix="$HOME/Projects/GridPACK-Wind/gridpack-install"
     cmake -Wdev --debug-trycompile \
         --graphviz=GridPACK.dot \
-          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.20.6" \
-          -D PETSC_ARCH:STRING="ubuntu-real-shared" \
+          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.21.6" \
+          -D PETSC_ARCH:STRING="ubuntu-real-shared-debug" \
           -D BOOST_ROOT:PATH="/usr" \
           -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
           -D PARMETIS_DIR:PATH="/usr" \

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -224,6 +224,14 @@ elif [ $host == "tlaloc" ]; then
     #      -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.19.4" \
     #      -D PETSC_ARCH:STRING="ubuntu-complex-shared-mumps" \
 
+    # Custom built 3.20, complex:
+    #      -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.20.6" \
+    #      -D PETSC_ARCH:STRING="ubuntu-complex-shared" \
+
+    # Custom built 3.20, real:
+    #      -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.20.6" \
+    #      -D PETSC_ARCH:STRING="ubuntu-real-shared" \
+    
     if [ -z "$GRIDPACK_DIR" ]; then
         prefix="$HOME/Projects/ExaLearn/gridpack-install"
     else
@@ -233,8 +241,8 @@ elif [ $host == "tlaloc" ]; then
     prefix="$HOME/Projects/GridPACK-Wind/gridpack-install"
     cmake -Wdev --debug-trycompile \
         --graphviz=GridPACK.dot \
-          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.19.4" \
-          -D PETSC_ARCH:STRING="ubuntu-complex-shared" \
+          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.20.6" \
+          -D PETSC_ARCH:STRING="ubuntu-real-shared" \
           -D BOOST_ROOT:PATH="/usr" \
           -D Boost_NO_BOOST_CMAKE:BOOL=TRUE \
           -D PARMETIS_DIR:PATH="/usr" \

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created October 17, 2013 by Bruce Palmer
-# Last Change: 2019-10-29 13:19:21 d3g096
+# Last Change: 2025-01-16 06:55:54 d3g096
 # -------------------------------------------------------------
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -114,6 +114,15 @@ if (GOSS_DIR)
   set(GRIDPACK_GOSS_LIBRARIES ${GOSS_LIBRARY})
   set(GRIDPACK_APR_LIBRARIES ${APR_LIBRARY})
 endif ()
+
+# Boost libaries are IMPORTed, so we need to find the actual library
+# locations for the configuration file
+set(Boost_Real_LIBRARIES "")
+foreach(l ${Boost_LIBRARIES})
+  get_target_property(_location ${l} LOCATION)
+  get_filename_component(_realpath ${_location} REALPATH)
+  list(APPEND Boost_Real_LIBRARIES ${_realpath})
+endforeach()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/GridPACK.cmake.in 
   ${CMAKE_CURRENT_BINARY_DIR}/GridPACK.cmake @ONLY)

--- a/src/lib/GridPACK.cmake.in
+++ b/src/lib/GridPACK.cmake.in
@@ -226,7 +226,7 @@ function(gridpack_setup)
   )
 
   list(APPEND gp_libs
-    @Boost_LIBRARIES@
+    @Boost_Real_LIBRARIES@
     @MPI_CXX_LIBRARIES@
   )
 

--- a/src/lib/GridPACK.cmake.in
+++ b/src/lib/GridPACK.cmake.in
@@ -221,7 +221,7 @@ function(gridpack_setup)
   endif()
 
   list(APPEND gp_include 
-    @Boost_INCLUDE_DIR@
+    @Boost_INCLUDE_DIRS@
     @MPI_INCLUDE_PATH@
   )
 

--- a/src/math/complex_operators.hpp
+++ b/src/math/complex_operators.hpp
@@ -301,7 +301,7 @@ imaginary_value<ComplexType>::operator() (const ComplexType& x) const
 // base_accumulator_function
 // -------------------------------------------------------------
 template <typename T, typename ResultType>
-struct base_accumulator_function : public std::__unary_function<T, void>
+struct base_accumulator_function
 {
   ResultType accum;
   virtual void operator() (const T& t) = 0;
@@ -310,7 +310,7 @@ struct base_accumulator_function : public std::__unary_function<T, void>
     return accum;
   }
   base_accumulator_function(void) 
-    : std::__unary_function<T, void>(), accum(0.0)
+    : accum(0.0)
   {}
 };
 

--- a/src/math/complex_operators.hpp
+++ b/src/math/complex_operators.hpp
@@ -10,7 +10,6 @@
 /**
  * @file   complex_operators.hpp
  * @author William A. Perkins
- * @date   2015-06-12 09:12:12 d3g096
  * 
  * @brief This header provides type interregation utilities and some math
  * operators for the math library
@@ -27,7 +26,6 @@
 #ifndef _complex_operators_hpp_
 #define _complex_operators_hpp_
 
-#include <functional>
 #include <algorithm>
 
 #include <boost/static_assert.hpp>
@@ -70,7 +68,7 @@ equate<RealType, ComplexType>(const ComplexType& f)
 // base_unary_function
 // -------------------------------------------------------------
 template <typename T>
-struct base_unary_function : public std::unary_function<T, T>
+struct base_unary_function
 {
   virtual T operator() (const T& t) const = 0;
 };
@@ -303,7 +301,7 @@ imaginary_value<ComplexType>::operator() (const ComplexType& x) const
 // base_accumulator_function
 // -------------------------------------------------------------
 template <typename T, typename ResultType>
-struct base_accumulator_function : public std::unary_function<T, void>
+struct base_accumulator_function : public std::__unary_function<T, void>
 {
   ResultType accum;
   virtual void operator() (const T& t) = 0;
@@ -312,7 +310,7 @@ struct base_accumulator_function : public std::unary_function<T, void>
     return accum;
   }
   base_accumulator_function(void) 
-    : std::unary_function<T, void>(), accum(0.0)
+    : std::__unary_function<T, void>(), accum(0.0)
   {}
 };
 
@@ -432,7 +430,7 @@ infinity_norm<ComplexType>::operator() (const ComplexType& x)
 // binary_operation
 // -------------------------------------------------------------
 template <typename T> 
-struct base_binary_function : public std::binary_function<T, T, T>
+struct base_binary_function
 {
   virtual T operator() (const T& x1, const T& x2) const = 0;
 };

--- a/src/math/petsc/petsc_dae_solver_implementation.hpp
+++ b/src/math/petsc/petsc_dae_solver_implementation.hpp
@@ -10,7 +10,7 @@
 /**
  * @file   petsc_dae_solver_implementation.hpp
  * @author William A. Perkins
- * @date   2024-10-10 08:41:42 d3g096
+ * @date   2025-01-23 07:52:50 d3g096
  * 
  * @brief  
  * 
@@ -295,7 +295,7 @@ protected:
       ierr = TSSetMaxSteps(p_ts, maxsteps); CHKERRXX(ierr);
       ierr = TSSetMaxTime(p_ts, maxtime); CHKERRXX(ierr);
       ierr = TSSetExactFinalTime(p_ts, TS_EXACTFINALTIME_MATCHSTEP); CHKERRXX(ierr); 
-      ierr = TSSolve(p_ts, PETSC_NULL);
+      ierr = TSSolve(p_ts, PETSC_NULLPTR);
       // std::cout << this->processor_rank() << ": "
       //           << "DAESolver::solve() returned " << ierr 
       //           << std::endl;
@@ -473,7 +473,11 @@ protected:
 
   /// Routine called every step if an event manager is specified
   static PetscErrorCode
+#if PETSC_VERSION_GE(3,21,0)
+  EventHandler(TS ts, PetscReal t, Vec U, PetscReal fvalue[], void* ctx)
+#else
   EventHandler(TS ts, PetscReal t, Vec U, PetscScalar fvalue[], void* ctx)
+#endif
   {
     PetscErrorCode ierr(0);
     void *dummy;
@@ -489,16 +493,23 @@ protected:
       state(new VectorType(new PETScVectorImplementation<T, I>(solver->communicator(),
                                                                U, false)));
 
-    // This gets a little tricky.  If PETSc is built w/ complex,
-    // fvalue will be complex, and evalues, whether real or complex,
-    // can be assigned directly.  If T is complex and PetscScalar is
-    // real, then equate<> will return the real part of T.  This is
-    // what PETSc does internally to check a complex event value. So,
-    // this *should* work for PETSc.
+    
+    // This gets a little tricky.  Before 3.21.0, if PETSc is built w/
+    // complex, fvalue will be complex, and evalues, whether real or
+    // complex, can be assigned directly.  If T is complex and
+    // PetscScalar is real, then equate<> will return the real part of
+    // T.  This is what PETSc does internally to check a complex event
+    // value. So, this *should* work for PETSc.  With 3.21.0 and
+    // later, fvalues is PetscReal.  Perhaps in the future, evalues
+    // should just be double?
 
     const T *evalues = solver->p_eventManager->values(t, *state);
     for (int i = 0; i < solver->p_eventManager->size(); ++i) {
+#if PETSC_VERSION_GE(3,21,0)
+      fvalue[i] = equate<PetscReal, T>(evalues[i]);
+#else
       fvalue[i] = equate<PetscScalar, T>(evalues[i]);
+#endif
     }
 
     ierr = VecAssemblyBegin(U);

--- a/src/math/petsc/petsc_exception.cpp
+++ b/src/math/petsc/petsc_exception.cpp
@@ -34,7 +34,7 @@ throw_petsc_exception(int line, const char *file, int ierr)
 {
   std::ostringstream msg;
   const char *buf;
-  PetscErrorMessage(ierr, &buf, PETSC_NULL);
+  PetscErrorMessage(ierr, &buf, PETSC_NULLPTR);
   msg << file << ": " << line << ": "
       << "PETSc Error (" << ierr << "): " << buf;
   throw PETSC_EXCEPTION_TYPE(msg.str());
@@ -53,7 +53,7 @@ PETScException::PETScException(const PetscErrorCode ierr)
   std::ostringstream msg;
   msg << "PETSc error (" << petsc_err_ << ")";
   const char *buf;
-  PetscErrorMessage(petsc_err_, &buf, PETSC_NULL);
+  PetscErrorMessage(petsc_err_, &buf, PETSC_NULLPTR);
   msg << ": " << buf;
   message_ = msg.str();
 }          

--- a/src/math/petsc/petsc_matrix_implementation.hpp
+++ b/src/math/petsc/petsc_matrix_implementation.hpp
@@ -152,10 +152,10 @@ public:
       ierr = MatSetSizes(mtmp, lrow, lcol, grow, gcol); CHKERRXX(ierr);
       if (comm.size() == 1) {
         ierr = MatSetType(mtmp, MATSEQDENSE); CHKERRXX(ierr);
-        ierr = MatSeqDenseSetPreallocation(mtmp, PETSC_NULL); CHKERRXX(ierr);
+        ierr = MatSeqDenseSetPreallocation(mtmp, PETSC_NULLPTR); CHKERRXX(ierr);
       } else {
         ierr = MatSetType(mtmp, MATDENSE); CHKERRXX(ierr);
-        ierr = MatMPIDenseSetPreallocation(mtmp, PETSC_NULL); CHKERRXX(ierr);
+        ierr = MatMPIDenseSetPreallocation(mtmp, PETSC_NULLPTR); CHKERRXX(ierr);
       }
       result = new PETScMatrixImplementation(mtmp, false);
     } catch (const PETSC_EXCEPTION_TYPE& e) {

--- a/src/math/petsc/petsc_matrix_wrapper.cpp
+++ b/src/math/petsc/petsc_matrix_wrapper.cpp
@@ -166,10 +166,10 @@ PetscMatrixWrapper::p_set_dense_matrix(void)
     parallel::Communicator comm(getCommunicator(p_matrix));
     if (comm.size() == 1) {
       ierr = MatSetType(p_matrix, MATSEQDENSE); CHKERRXX(ierr);
-      ierr = MatSeqDenseSetPreallocation(p_matrix, PETSC_NULL); CHKERRXX(ierr);
+      ierr = MatSeqDenseSetPreallocation(p_matrix, PETSC_NULLPTR); CHKERRXX(ierr);
     } else {
       ierr = MatSetType(p_matrix, MATDENSE); CHKERRXX(ierr);
-      ierr = MatMPIDenseSetPreallocation(p_matrix, PETSC_NULL); CHKERRXX(ierr);
+      ierr = MatMPIDenseSetPreallocation(p_matrix, PETSC_NULLPTR); CHKERRXX(ierr);
     }
   } catch (const PETSC_EXCEPTION_TYPE& e) {
     throw PETScException(ierr, e);
@@ -211,14 +211,14 @@ PetscMatrixWrapper::p_set_sparse_matrix(const PetscInt& max_nz_per_row)
       ierr = MatSetType(p_matrix, MATSEQAIJ); CHKERRXX(ierr);
       ierr = MatSeqAIJSetPreallocation(p_matrix, 
                                        diagonal_non_zero_guess + offdiagonal_non_zero_guess,
-                                       PETSC_NULL); CHKERRXX(ierr);
+                                       PETSC_NULLPTR); CHKERRXX(ierr);
     } else {
       ierr = MatSetType(p_matrix, MATMPIAIJ); CHKERRXX(ierr);
       ierr = MatMPIAIJSetPreallocation(p_matrix, 
                                        diagonal_non_zero_guess,
-                                       PETSC_NULL,
+                                       PETSC_NULLPTR,
                                        offdiagonal_non_zero_guess, 
-                                       PETSC_NULL); CHKERRXX(ierr);
+                                       PETSC_NULLPTR); CHKERRXX(ierr);
     }
     ierr = MatSetFromOptions(p_matrix); CHKERRXX(ierr);
     ierr = MatSetUp(p_matrix); CHKERRXX(ierr);
@@ -291,7 +291,7 @@ PetscMatrixWrapper::rows(void) const
   PetscInt result(0);
   try {
     PetscInt rows;
-    ierr = MatGetSize(p_matrix, &rows, PETSC_NULL); CHKERRXX(ierr);
+    ierr = MatGetSize(p_matrix, &rows, PETSC_NULLPTR); CHKERRXX(ierr);
     result = rows;
   } catch (const PETSC_EXCEPTION_TYPE& e) {
     throw PETScException(ierr, e);
@@ -309,7 +309,7 @@ PetscMatrixWrapper::localRows(void) const
   PetscInt result(0);
   try {
     PetscInt rows;
-    ierr = MatGetLocalSize(p_matrix, &rows, PETSC_NULL); CHKERRXX(ierr);
+    ierr = MatGetLocalSize(p_matrix, &rows, PETSC_NULLPTR); CHKERRXX(ierr);
     result = rows;
   } catch (const PETSC_EXCEPTION_TYPE& e) {
     throw PETScException(ierr, e);
@@ -327,7 +327,7 @@ PetscMatrixWrapper::cols(void) const
   PetscInt result(0);
   try {
     PetscInt cols;
-    ierr = MatGetSize(p_matrix, PETSC_NULL, &cols); CHKERRXX(ierr);
+    ierr = MatGetSize(p_matrix, PETSC_NULLPTR, &cols); CHKERRXX(ierr);
     result = cols;
   } catch (const PETSC_EXCEPTION_TYPE& e) {
     throw PETScException(ierr, e);
@@ -345,7 +345,7 @@ PetscMatrixWrapper::localCols(void) const
   PetscInt result(0);
   try {
     PetscInt cols;
-    ierr = MatGetLocalSize(p_matrix, PETSC_NULL, &cols); CHKERRXX(ierr);
+    ierr = MatGetLocalSize(p_matrix, PETSC_NULLPTR, &cols); CHKERRXX(ierr);
     result = cols;
   } catch (const PETSC_EXCEPTION_TYPE& e) {
     throw PETScException(ierr, e);

--- a/src/math/petsc/petsc_nonlinear_solver_implementation.hpp
+++ b/src/math/petsc/petsc_nonlinear_solver_implementation.hpp
@@ -127,7 +127,7 @@ protected:
       // set the 
       ierr = SNESSetOptionsPrefix(p_snes, option_prefix.c_str()); CHKERRXX(ierr);
 
-      ierr = SNESMonitorSet(p_snes, MonitorNorms, PETSC_NULL, PETSC_NULL); CHKERRXX(ierr);
+      ierr = SNESMonitorSet(p_snes, MonitorNorms, PETSC_NULLPTR, PETSC_NULLPTR); CHKERRXX(ierr);
 
       ierr = SNESSetTolerances(p_snes, 
                                this->p_functionTolerance, 

--- a/src/math/test/dae_solver_test.cpp
+++ b/src/math/test/dae_solver_test.cpp
@@ -9,7 +9,7 @@
 /**
  * @file   dae_solver_test.cpp
  * @author William A. Perkins
- * @date   2023-09-13 07:44:15 d3g096
+ * @date   2024-08-20 06:46:59 d3g096
  * 
  * @brief  
  * 
@@ -122,7 +122,7 @@ public:
     postfunc = &reportPostTime;
     solver.postStep(postfunc);
 
-    std::auto_ptr<VectorType> x(initial(comm));
+    std::unique_ptr<VectorType> x(initial(comm));
     
     double t0(0.0), t(t0);
     solver.initialize(t0, 0.001, *x);
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE( Rober )
 {
   gridpack::parallel::Communicator world;
 
-  std::auto_ptr<Problem> p(new RoberProblem());
+  std::unique_ptr<Problem> p(new RoberProblem());
 
   p->solve(world, test_config);
 }
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE( Orego )
 {
   gridpack::parallel::Communicator world;
 
-  std::auto_ptr<Problem> p(new OregoProblem());
+  std::unique_ptr<Problem> p(new OregoProblem());
 
   p->solve(world, test_config);
 
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE( CE )
 {
   gridpack::parallel::Communicator world;
 
-  std::auto_ptr<Problem> p(new CEProblem());
+  std::unique_ptr<Problem> p(new CEProblem());
 
   p->solve(world, test_config);
 

--- a/src/math/test/linear_solver_test.cpp
+++ b/src/math/test/linear_solver_test.cpp
@@ -8,7 +8,7 @@
 /**
  * @file   linear_solver_test.cpp
  * @author William A. Perkins
- * @date   2016-12-16 09:30:03 d3g096
+ * @date   2024-08-20 06:39:00 d3g096
  * 
  * @brief  
  * 
@@ -17,6 +17,7 @@
 // -------------------------------------------------------------
 
 #include <iostream>
+#include <memory>
 #include <boost/scoped_ptr.hpp>
 #include <boost/format.hpp>
 #include "linear_solver.hpp"
@@ -140,10 +141,10 @@ BOOST_AUTO_TEST_CASE( Versteeg )
   }
     
 
-  std::auto_ptr<gridpack::math::RealMatrix> 
+  std::unique_ptr<gridpack::math::RealMatrix> 
     A(new gridpack::math::RealMatrix(world, local_size, local_size, 
                                  gridpack::math::Sparse));
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     b(new gridpack::math::RealVector(world, local_size)),
     x(new gridpack::math::RealVector(world, local_size));
 
@@ -157,14 +158,14 @@ BOOST_AUTO_TEST_CASE( Versteeg )
   A->print();
   b->print();
 
-  std::auto_ptr<gridpack::math::RealLinearSolver> 
+  std::unique_ptr<gridpack::math::RealLinearSolver> 
     solver(new gridpack::math::RealLinearSolver(*A));
 
   BOOST_REQUIRE(test_config);
   solver->configure(test_config);
   solver->solve(*b, *x);
 
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     res(multiply(*A, *x));
   res->add(*b, -1.0);
 
@@ -238,33 +239,33 @@ BOOST_AUTO_TEST_CASE ( VersteegInverse )
   }
     
 
-  std::auto_ptr<gridpack::math::RealMatrix> 
+  std::unique_ptr<gridpack::math::RealMatrix> 
     A(new gridpack::math::RealMatrix(world, local_size, local_size, 
                                  gridpack::math::Sparse)),
     I(new gridpack::math::RealMatrix(world, local_size, local_size, 
                                  gridpack::math::Sparse));
   I->identity();
 
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     b(new gridpack::math::RealVector(world, local_size));
 
   assemble(imax, jmax, *A, *b);
   A->ready();
   b->ready();
 
-  std::auto_ptr<gridpack::math::RealLinearSolver> 
+  std::unique_ptr<gridpack::math::RealLinearSolver> 
     solver(new gridpack::math::RealLinearSolver(*A));
 
   BOOST_REQUIRE(test_config);
   solver->configurationKey("LinearMatrixSolver");
   solver->configure(test_config);
 
-  std::auto_ptr<gridpack::math::RealMatrix> 
+  std::unique_ptr<gridpack::math::RealMatrix> 
     Ainv(solver->solve(*I));
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     x(multiply(*Ainv, *b));
 
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     res(multiply(*A, *x));
   res->add(*b, -1.0);
   res->print();
@@ -335,12 +336,12 @@ BOOST_AUTO_TEST_CASE ( VersteegMatrixInverse )
   solver->configurationKey("LinearMatrixSolver");
   solver->configure(test_config);
 
-  std::auto_ptr<gridpack::math::RealMatrix> 
+  std::unique_ptr<gridpack::math::RealMatrix> 
     Ainv(solver->solve(*I));
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     x(multiply(*Ainv, *b));
 
-  std::auto_ptr<gridpack::math::RealVector>
+  std::unique_ptr<gridpack::math::RealVector>
     res(multiply(*A, *x));
   res->add(*b, -1.0);
 

--- a/src/parallel/CMakeLists.txt
+++ b/src/parallel/CMakeLists.txt
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
-# Last Change: 2020-05-22 09:41:25 d3g096
+# Last Change: 2024-11-27 08:43:27 d3g096
 # -------------------------------------------------------------
 
 set(target_libraries
@@ -100,7 +100,7 @@ if (NOT USE_PROGRESS_RANKS)
 endif()
 
 add_test(greetings_parallel 
-  ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} greetings ${MPIEXEC_POSTFLAGS})
+  ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ./greetings ${MPIEXEC_POSTFLAGS})
 set_tests_properties(greetings_parallel
   PROPERTIES 
   PASS_REGULAR_EXPRESSION "I am process 0 of [1-9].*$"

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
-# Last Change: 2022-09-07 07:21:23 d3g096
+# Last Change: 2024-08-20 07:19:18 d3g096
 # -------------------------------------------------------------
 
 set(target_libraries
@@ -30,10 +30,8 @@ set(target_libraries
     gridpack_environment
     gridpack_math
     gridpack_partition
-    gridpack_components
     gridpack_parallel
     gridpack_timer
-    gridpack_stream
     ${target_libraries})
 
 add_library(gridpack_block_parsers
@@ -69,7 +67,10 @@ add_library(gridpack_block_parsers
     block_parsers/switched_shunt_parser35.cpp
     )
 gridpack_set_library_version(gridpack_block_parsers)
-add_dependencies(gridpack_block_parsers external_build)
+target_link_libraries(gridpack_block_parsers
+  gridpack_components
+  gridpack_stream
+)
 
 include_directories(AFTER parser_classes)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -85,7 +86,7 @@ endif()
 #target_link_libraries(PTI23_test ${target_libraries})
 
 add_executable(parser_test test/parser_test.cpp)
-target_link_libraries(parser_test ${target_libraries})
+target_link_libraries(parser_test gridpack_block_parsers ${target_libraries})
 
 add_custom_target(test_parser_input
 
@@ -120,7 +121,7 @@ gridpack_add_run_test(parser_test parser_test "IEEE14.raw")
 # TEST: hash_distr_test
 # -------------------------------------------------------------
 add_executable(hash_distr_test test/hash_distr_test.cpp)
-target_link_libraries(hash_distr_test ${target_libraries})
+target_link_libraries(hash_distr_test gridpack_components ${target_libraries})
 
 gridpack_add_unit_test(hash_distr_test hash_distr_test)
 
@@ -128,7 +129,7 @@ gridpack_add_unit_test(hash_distr_test hash_distr_test)
 # TEST: bus_table_test
 # -------------------------------------------------------------
 add_executable(bus_table_test test/bus_table_test.cpp)
-target_link_libraries(bus_table_test ${target_libraries})
+target_link_libraries(bus_table_test gridpack_components ${target_libraries})
 
 # -------------------------------------------------------------
 # installation

--- a/src/partition/test/parmetis_test.cpp
+++ b/src/partition/test/parmetis_test.cpp
@@ -6,7 +6,7 @@
 /**
  * @file   parmetis_test.cpp
  * @author William A. Perkins
- * @date   2014-02-10 08:31:20 d3g096
+ * @date   2024-08-20 06:49:56 d3g096
  * 
  * @brief  Unit tests of ParMETIS-specific code
  * 
@@ -38,10 +38,10 @@ BOOST_AUTO_TEST_CASE( graph_wrapper )
   using gridpack::network::AdjacencyList;
   using gridpack::network::ParMETISGraphWrapper;
 
-  std::auto_ptr<AdjacencyList> 
+  std::unique_ptr<AdjacencyList> 
     adlist(simple_adjacency_list(world, global_nodes));
 
-  std::auto_ptr<ParMETISGraphWrapper>
+  std::unique_ptr<ParMETISGraphWrapper>
     wrapper(new ParMETISGraphWrapper(*adlist));
 
   std::vector<idx_t> vtxdist;

--- a/src/partition/test/partition_test.cpp
+++ b/src/partition/test/partition_test.cpp
@@ -7,7 +7,7 @@
 /**
  * @file   partition_test.cpp
  * @author William A. Perkins
- * @date   2014-12-09 10:01:37 d3g096
+ * @date   2024-08-20 06:49:16 d3g096
  * 
  * @brief  Unit test suite for various partition classes.
  * 
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE( adjacency )
   
   using gridpack::network::AdjacencyList;
 
-  std::auto_ptr<AdjacencyList> 
+  std::unique_ptr<AdjacencyList> 
     adlist(simple_adjacency_list(world, global_nodes));
 
   for (int p = 0; p < world.size(); ++p) {
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE( random_partition )
   
   using gridpack::network::GraphPartitioner;
 
-  std::auto_ptr<GraphPartitioner> 
+  std::unique_ptr<GraphPartitioner> 
     partitioner(simple_graph_partitioner(world, global_nodes));
 
   partitioner->partition();

--- a/src/stream/CMakeLists.txt
+++ b/src/stream/CMakeLists.txt
@@ -10,7 +10,7 @@
 # -------------------------------------------------------------
 # -------------------------------------------------------------
 # Created May  6, 2013 by William A. Perkins
-# Last Change: 2018-09-20 11:18:01 d3g096
+# Last Change: 2024-08-20 07:43:59 d3g096
 # -------------------------------------------------------------
 
 add_library(gridpack_stream
@@ -18,17 +18,9 @@ add_library(gridpack_stream
 )
 
 gridpack_set_library_version(gridpack_stream)
-add_dependencies(gridpack_stream external_build)
-
-if (GRIDPACK_LIB_LINK_LIBRARIES)
-  target_link_libraries(gridpack_stream)
-endif()
 
 set(target_libraries
-    gridpack_stream
-    ${GA_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${MPI_CXX_LIBRARIES}
+  gridpack_stream
 )
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This PR provides changes necessary to build GridPACK on Mac OS X, particularly with shared libraries and the Python interface.  This resolves #217 (mostly) in order to build with modern CLang compilers.  Probably resolves #197 too. 