### PR TITLE
Provide feature to update DataCollections with simulation results

### DIFF
--- a/python/src/dsf.py
+++ b/python/src/dsf.py
@@ -94,6 +94,7 @@ ds_app.solvePreInitialize(faults[0])
 
 while (not ds_app.isDynSimuDone()):
     ds_app.executeOneSimuStep()
+    ds_app.updateData()
 
 network_analytics_dump(ds_app)
 

--- a/python/src/dsf.py
+++ b/python/src/dsf.py
@@ -47,10 +47,10 @@ def network_analytics_dump(ds_app):
         print(branch, f, t, 
               ds_app.getBranchInfoInt(branch, "BRANCH_ELEMENTS"),
               ds_app.getBranchInfoInt(branch, "BRANCH_INDEX"),
-              ds_app.getBranchInfoString(branch, "BRANCH_NAME"),
-              ds_app.getBranchInfoReal(branch, "BRANCH_LENGTH"))
-              
-            
+              ds_app.getBranchInfoReal(branch, 'BRANCH_FROM_P_CURRENT'),
+              ds_app.getBranchInfoReal(branch, 'BRANCH_TO_P_CURRENT'),
+              ds_app.getBranchInfoReal(branch, 'BRANCH_FROM_Q_CURRENT'),
+              ds_app.getBranchInfoReal(branch, 'BRANCH_TO_Q_CURRENT'))
 
 # -------------------------------------------------------------
 # variable initialization

--- a/python/src/dsf.py
+++ b/python/src/dsf.py
@@ -28,13 +28,19 @@ def network_analytics_dump(ds_app):
                   ds_app.getBusInfoInt(bus, "GENERATOR_NUMBER", g),
                   ds_app.getBusInfoString(bus, "GENERATOR_ID", g),
                   ds_app.getBusInfoReal(bus, "GENERATOR_PG", g),
-                  ds_app.getBusInfoReal(bus, "GENERATOR_QG", g))
+                  ds_app.getBusInfoReal(bus, "GENERATOR_QG", g),
+                  ds_app.getBusInfoReal(bus, "GENERATOR_PG_CURRENT", g),
+                  ds_app.getBusInfoReal(bus, "GENERATOR_QG_CURRENT", g),
+                  )
         for l in range(ds_app.numLoads(bus)):
             print("load: ", l,
                   ds_app.getBusInfoInt(bus, "LOAD_NUMBER", l),
                   ds_app.getBusInfoString(bus, "LOAD_ID", l),
                   ds_app.getBusInfoReal(bus, "LOAD_PL", l),
-                  ds_app.getBusInfoReal(bus, "LOAD_QL", l))
+                  ds_app.getBusInfoReal(bus, "LOAD_QL", l),
+                  ds_app.getBusInfoReal(bus, "LOAD_PL_CURRENT", l),
+                  ds_app.getBusInfoReal(bus, "LOAD_QL_CURRENT", l)
+                  )
     nbranch = ds_app.totalBranches()
     for branch in range(0, nbranch):
         (f, t) = ds_app.getBranchEndpoints(branch)
@@ -94,8 +100,8 @@ ds_app.solvePreInitialize(faults[0])
 
 while (not ds_app.isDynSimuDone()):
     ds_app.executeOneSimuStep()
-    ds_app.updateData()
 
+ds_app.updateData()
 network_analytics_dump(ds_app)
 
 timer.stop(t_total)

--- a/python/src/dsf.py
+++ b/python/src/dsf.py
@@ -44,13 +44,14 @@ def network_analytics_dump(ds_app):
     nbranch = ds_app.totalBranches()
     for branch in range(0, nbranch):
         (f, t) = ds_app.getBranchEndpoints(branch)
-        print(branch, f, t, 
-              ds_app.getBranchInfoInt(branch, "BRANCH_ELEMENTS"),
-              ds_app.getBranchInfoInt(branch, "BRANCH_INDEX"),
-              ds_app.getBranchInfoReal(branch, 'BRANCH_FROM_P_CURRENT'),
-              ds_app.getBranchInfoReal(branch, 'BRANCH_TO_P_CURRENT'),
-              ds_app.getBranchInfoReal(branch, 'BRANCH_FROM_Q_CURRENT'),
-              ds_app.getBranchInfoReal(branch, 'BRANCH_TO_Q_CURRENT'))
+        nelem = ds_app.getBranchInfoInt(branch, "BRANCH_NUM_ELEMENTS")
+        for e in range(0, nelem):
+            print(branch, ds_app.getBranchInfoInt(branch, "BRANCH_INDEX"),
+                  f, t, e, 
+                  ds_app.getBranchInfoReal(branch, 'BRANCH_FROM_P_CURRENT', e),
+                  ds_app.getBranchInfoReal(branch, 'BRANCH_TO_P_CURRENT', e),
+                  ds_app.getBranchInfoReal(branch, 'BRANCH_FROM_Q_CURRENT', e),
+                  ds_app.getBranchInfoReal(branch, 'BRANCH_TO_Q_CURRENT', e))
 
 # -------------------------------------------------------------
 # variable initialization

--- a/python/src/example/39bus_test_example_dsf.py
+++ b/python/src/example/39bus_test_example_dsf.py
@@ -12,6 +12,29 @@ import numpy as np
 from gridpack.dynamic_simulation import DSFullApp, Event, EventVector
 
 # -------------------------------------------------------------
+# network_dump_state
+# this matches (some) generator power observations output
+# -------------------------------------------------------------
+def network_dump_state(ds_app):
+    nbus = ds_app.totalBuses()
+    for bus in range(nbus):
+        print(bus,
+              ds_app.getBusInfoInt(bus, "BUS_NUMBER"),
+              ds_app.getBusInfoString(bus, "BUS_NAME"),
+              ds_app.getBusInfoReal(bus, "BUS_VOLTAGE_MAG"))
+        for g in range(ds_app.numGenerators(bus)):
+            print(" gen: ", g,
+                  ds_app.getBusInfoReal(bus, "GENERATOR_PG_CURRENT", g),
+                  ds_app.getBusInfoReal(bus, "GENERATOR_QG_CURRENT", g),
+                  )
+        for l in range(ds_app.numLoads(bus)):
+            print("load: ", l,
+                  ds_app.getBusInfoInt(bus, "LOAD_NUMBER", l),
+                  ds_app.getBusInfoReal(bus, "LOAD_PL_CURRENT", l),
+                  ds_app.getBusInfoReal(bus, "LOAD_QL_CURRENT", l)
+                  )
+
+# -------------------------------------------------------------
 # variable initialization
 # -------------------------------------------------------------
 program = os.path.basename(sys.argv[0])
@@ -85,6 +108,8 @@ dt = ds_app.getTimeStep()
 outputob_time_step = 0.005
 outputob_nsimustep = int(outputob_time_step/dt);
 
+ds_app.updateData()
+network_dump_state(ds_app)
 
 isteps = 0
 while (not ds_app.isDynSimuDone()):
@@ -108,6 +133,8 @@ while (not ds_app.isDynSimuDone()):
         ob_vals.extend(vAng)
         ob_vals.extend(fOnline)
         ob_vals.extend(busfreq)
+        ds_app.updateData()
+        network_dump_state(ds_app)
         print('After getObservations')
         
         print('Before insert')
@@ -115,6 +142,8 @@ while (not ds_app.isDynSimuDone()):
         print('After insert')
     isteps = isteps + 1
 
+network_dump_state(ds_app)
+                   
 np_data = np.array(observation_list)
 
 import pandas as pd

--- a/python/src/example/39bus_test_example_dsf.py
+++ b/python/src/example/39bus_test_example_dsf.py
@@ -21,9 +21,10 @@ def network_dump_state(ds_app):
         print(bus,
               ds_app.getBusInfoInt(bus, "BUS_NUMBER"),
               ds_app.getBusInfoString(bus, "BUS_NAME"),
-              ds_app.getBusInfoReal(bus, "BUS_VOLTAGE_MAG"))
+              ds_app.getBusInfoReal(bus, "BUS_VMAG_CURRENT"))
         for g in range(ds_app.numGenerators(bus)):
             print(" gen: ", g,
+                  ds_app.getBusInfoString(bus, "GENERATOR_MODEL", g),
                   ds_app.getBusInfoReal(bus, "GENERATOR_PG_CURRENT", g),
                   ds_app.getBusInfoReal(bus, "GENERATOR_QG_CURRENT", g),
                   )

--- a/python/src/gridpack.cpp
+++ b/python/src/gridpack.cpp
@@ -479,6 +479,7 @@ PYBIND11_MODULE(gridpack, gpm) {
            return py::make_tuple(total, pmin, pmax);
          })
     .def("resetPower", &gpds::DSFullApp::resetPower)
+    .def("updateData", &gpds::DSFullApp::updateData)
     .def("writeRTPRDiagnostics",
          [](gpds::DSFullApp& self,
             int src_area, int src_zone, int load_area,
@@ -767,6 +768,7 @@ PYBIND11_MODULE(gridpack, gpm) {
     .def(py::init<>())
     .def("transferPFtoDS", &gph::HADRECAppModule::transferPFtoDS)
     .def("executeDynSimuOneStep", &gph::HADRECAppModule::executeDynSimuOneStep)
+    .def("updateData", &gph::HADRECAppModule::updateData)
     .def("isDynSimuDone",  &gph::HADRECAppModule::isDynSimuDone)
     .def("applyAction", &gph::HADRECAppModule::applyAction)
     .def("getObservations", &gph::HADRECAppModule::getObservations,

--- a/python/src/gridpack.cpp
+++ b/python/src/gridpack.cpp
@@ -22,6 +22,7 @@ namespace py = pybind11;
 #include <gridpack/configuration/no_print.hpp>
 #include <gridpack/parallel/communicator.hpp>
 #include <gridpack/parallel/task_manager.hpp>
+#include <gridpack/applications/modules/dynamic_simulation_full_y/dsf_app_module.hpp>
 #include <gridpack/applications/modules/hadrec/hadrec_app_module.hpp>
 #include <gridpack/timer/coarse_timer.hpp>
 
@@ -327,16 +328,23 @@ PYBIND11_MODULE(gridpack, gpm) {
   // -------------------------------------------------------------
   py::class_<gpds::Event>(dsm, "Event")
     .def(py::init<>())
-    .def_readwrite("start", &gpds::Event::start)
-    .def_readwrite("end", &gpds::Event::end)
-    .def_readwrite("step", &gpds::Event::step)
-    .def_readwrite("tag", &gpds::Event::tag)
     .def_readwrite("isGenerator", &gpds::Event::isGenerator)
     .def_readwrite("isBus", &gpds::Event::isBus)
-    .def_readwrite("bus_idx", &gpds::Event::bus_idx)
     .def_readwrite("isLine", &gpds::Event::isLine)
+    .def_readwrite("isBusFault", &gpds::Event::isBusFault)
+    .def_readwrite("isLineStatus", &gpds::Event::isLineStatus)
+    .def_readwrite("isGenStatus", &gpds::Event::isGenStatus)
+    .def_readwrite("start", &gpds::Event::start)
+    .def_readwrite("end", &gpds::Event::end)
+    .def_readwrite("bus_idx", &gpds::Event::bus_idx)
+    .def_readwrite("Gfault", &gpds::Event::Gfault)
+    .def_readwrite("Bfault", &gpds::Event::Bfault)
+    .def_readwrite("time", &gpds::Event::time)
+    .def_readwrite("tag", &gpds::Event::tag)
     .def_readwrite("from_idx", &gpds::Event::from_idx)
     .def_readwrite("to_idx", &gpds::Event::to_idx)
+    .def_readwrite("status", &gpds::Event::status)
+    .def_readwrite("step", &gpds::Event::step)
     ;
 
   // -------------------------------------------------------------

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_exciter_model.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_exciter_model.cpp
@@ -48,6 +48,18 @@ void gridpack::dynamic_simulation::BaseExciterModel::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * exciter
+ * @param data collection object for bus that hosts exciter
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::BaseExciterModel::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection>
+    data, int idx)
+{
+}
+
+/**
  * Initialize exciter model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_exciter_model.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_exciter_model.hpp
@@ -45,6 +45,15 @@ class BaseExciterModel
         data, int idx);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * exciter
+     * @param data collection object for bus that hosts exciter
+     * @param index of generator on bus
+     */
+    virtual void updateData(boost::shared_ptr<gridpack::component::DataCollection>
+        data, int idx);
+
+    /**
      * Initialize exciter model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_generator_model.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_generator_model.cpp
@@ -54,6 +54,16 @@ void gridpack::dynamic_simulation::BaseGeneratorModel::load(
     boost::shared_ptr<gridpack::component::DataCollection> data, int idx) {}
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * generator
+ * @param data collection object for bus that hosts generator
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::BaseGeneratorModel::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx) {}
+
+
+/**
  * Initialize generator model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_generator_model.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_generator_model.hpp
@@ -48,9 +48,17 @@ public:
    * Load parameters from DataCollection object into generator model
    * @param data collection of generator parameters from input files
    * @param index of generator on bus
-   * TODO: might want to move this functionality to BaseGeneratorModel
    */
   virtual void load(boost::shared_ptr<gridpack::component::DataCollection> data,
+                    int idx);
+
+  /**
+   * Update parameters in DataCollection object with current values from
+   * generator
+   * @param data collection object for bus that hosts generator
+   * @param index of generator on bus
+   */
+  virtual void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
                     int idx);
 
   /**

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_governor_model.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_governor_model.cpp
@@ -48,6 +48,18 @@ void gridpack::dynamic_simulation::BaseGovernorModel::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * governor
+ * @param data collection object for bus that hosts governor
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::BaseGovernorModel::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection>
+    data, int idx)
+{
+}
+
+/**
  * Initialize governor model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_governor_model.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_governor_model.hpp
@@ -45,6 +45,15 @@ class BaseGovernorModel
         data, int idx);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * governor
+     * @param data collection object for bus that hosts governor
+     * @param index of generator on bus
+     */
+    virtual void updateData(boost::shared_ptr<gridpack::component::DataCollection>
+        data, int idx);
+
+    /**
      * Initialize governor model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_load_model.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_load_model.cpp
@@ -50,6 +50,17 @@ void gridpack::dynamic_simulation::BaseLoadModel::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * load
+ * @param data collection object for bus that hosts load
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::BaseLoadModel::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+}
+
+/**
  * Initialize load model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/base_classes/base_load_model.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/base_classes/base_load_model.hpp
@@ -44,6 +44,15 @@ class BaseLoadModel
         data, int idx, double loadP, double loadQ, int ibCMPL);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * load
+     * @param data collection object for bus that hosts load
+     * @param index of generator on bus
+     */
+    virtual void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx);
+
+    /**
      * Initialize load model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_app_module.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_app_module.cpp
@@ -1619,6 +1619,15 @@ void gridpack::dynamic_simulation::DSFullApp::resetPower()
 }
 
 /**
+ * Update data collection objects for all buses and branches with
+ * current values from simulations
+ */
+void gridpack::dynamic_simulation::DSFullApp::updateData()
+{
+  return p_factory->updateData();
+}
+
+/**
  * Read in loads that should be monitored during simulation
  */
 void gridpack::dynamic_simulation::DSFullApp::setLoadWatch()

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_app_module.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_app_module.hpp
@@ -420,6 +420,12 @@ class DSFullApp
     void resetPower();
 
     /**
+     * Update data collection objects for all buses and branches with
+     * current values from simulations
+     */
+    void updateData();
+
+    /**
      * Write real time path rating diagnostics
      * @param src_area generation area
      * @param src_zone generation zone

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_app_module2.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_app_module2.cpp
@@ -251,6 +251,9 @@ void gridpack::dynamic_simulation::DSFullApp::runonestep()
 
   /* Update frequency */
   p_factory->updateBusFreq(p_time_step);
+
+  /* yuan add: update branch power*/
+  p_factory->updateData();
 	
   std::vector <double> vwideareafreqs;
   vwideareafreqs = p_factory->grabWideAreaFreq();

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -3566,13 +3566,14 @@ void gridpack::dynamic_simulation::DSFullBranch::load(
 void gridpack::dynamic_simulation::DSFullBranch::updateData(
     boost::shared_ptr<gridpack::component::DataCollection> &data)
 {
+#if 0
   int i;
-//  gridpack::dynamic_simulation::DSFullBus *bus1 = getBus1();
   for (i=0; i<p_elems; i++) {
     if (p_xform[i]) {
     } else {
     }
   }
+#endif
 }
 
 /**

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -1292,11 +1292,32 @@ void gridpack::dynamic_simulation::DSFullBus::updateData(
     boost::shared_ptr<gridpack::component::DataCollection> &data)
 {
   int i;
+  std::string name;
   for (i=0; i<p_ngen; i++) {
-    p_generators[i]->updateData(data, i);
+    if (data->getValue(GENERATOR_MODEL,&name,i)) {
+      p_generators[i]->updateData(data, i);
+    } else {
+      if (!data->setValue(GENERATOR_PG_CURRENT, p_pg[i], i)) {
+        data->addValue(GENERATOR_PG_CURRENT, p_pg[i], i);
+      }
+      if (!data->setValue(GENERATOR_QG_CURRENT, p_qg[i], i)) {
+        data->addValue(GENERATOR_QG_CURRENT, p_qg[i], i);
+      }
+    }
   }
-  for (i=0; i<p_ndyn_load; i++) {
-    p_loadmodels[i]->updateData(data, i);
+  int lcnt = 0;
+  for (i=0; i<p_npowerflow_load; i++) {
+    if (data->getValue(LOAD_MODEL,&name,i)) {
+      p_loadmodels[lcnt]->updateData(data, i);
+      lcnt++;
+    } else {
+      if (!data->setValue(LOAD_PL_CURRENT, p_powerflowload_p[i], i)) {
+        data->addValue(LOAD_PL_CURRENT, p_powerflowload_p[i], i);
+      }
+      if (!data->setValue(LOAD_QL_CURRENT, p_powerflowload_q[i], i)) {
+        data->addValue(LOAD_QL_CURRENT, p_powerflowload_q[i], i);
+      }
+    }
   }
 }
 

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -3563,17 +3563,80 @@ void gridpack::dynamic_simulation::DSFullBranch::load(
  * Update data collection object with current values from simulation
  * @param data: DataCollection object containing parameters for this branch
  */
-void gridpack::dynamic_simulation::DSFullBranch::updateData(
+void gridpack::dynamic_simulation::DSFullBranch::updateBranchPower(
     boost::shared_ptr<gridpack::component::DataCollection> &data)
 {
-#if 0
-  int i;
-  for (i=0; i<p_elems; i++) {
-    if (p_xform[i]) {
-    } else {
-    }
-  }
-#endif
+// #if 0
+//   int i;
+//   for (i=0; i<p_elems; i++) {
+//     if (p_xform[i]) {
+//     } else {
+//     }
+//   }
+// #endif
+
+	int i;
+	double dbranchR, dbranchX;
+  double dbranchB; 
+  double dbranchPhaseShift, dbranchTapRatio;
+	
+	gridpack::dynamic_simulation::DSFullBus *bus1 =
+    dynamic_cast<gridpack::dynamic_simulation::DSFullBus*>(getBus1().get());
+    gridpack::dynamic_simulation::DSFullBus *bus2 =
+    dynamic_cast<gridpack::dynamic_simulation::DSFullBus*>(getBus2().get());
+	
+	//get bus voltages
+	gridpack::ComplexType c_Z, c_branchcurr;
+  gridpack::ComplexType c_Ysh, c_frombusshuntcurr, c_tobusshuntcurr;
+  gridpack::ComplexType c_branchfrombuspq, c_branchtobuspq;
+	p_branchfrombusvolt = bus1->getComplexVoltage();
+	p_branchtobusvolt = bus2->getComplexVoltage();
+	
+	// printf ("Branch volts bus1, %8.4f+%8.4fj,  bus 2, %8.4f+%8.4fj,\n", real(p_branchfrombusvolt), 
+	// 		imag(p_branchfrombusvolt), real(p_branchtobusvolt),imag(p_branchtobusvolt) );
+	
+	if (!p_branchfrombuspq.empty()){
+		p_branchfrombuspq.clear();
+	}
+
+  if (!p_branchtobuspq.empty()){
+		p_branchtobuspq.clear();
+	}
+	
+	for ( i=0 ; i<p_elems ; i++ ) {
+		dbranchR = p_resistance[i];
+		dbranchX = p_reactance[i];
+    dbranchB = p_charging[i];
+    dbranchPhaseShift = p_phase_shift[i];
+    dbranchTapRatio = p_tap_ratio[i];
+
+		// printf ("Branch %d impedance, %8.4f+%8.4fj \n", i, dbranchR, dbranchX); 
+    // printf ("Branch %d shunt susceptance, %8.4fj \n", i, dbranchB); 
+    // printf ("Branch %d phase shift, %8.4f \n", i, dbranchPhaseShift); 
+    // printf ("Branch %d tap ratio, %8.4f \n", i, dbranchTapRatio); 
+
+		c_Z = gridpack::ComplexType(dbranchR, dbranchX);
+    c_Ysh = gridpack::ComplexType(0, dbranchB/2.0); // shunt susceptance at either end of a branch
+		c_branchcurr = (p_branchfrombusvolt - p_branchtobusvolt)/c_Z;
+		p_branchcurrent.push_back(c_branchcurr);
+		// printf ("Branch %d element current, %8.4f+%8.4fj \n", i, real(p_branchcurrent[i]), 
+		// 	imag(p_branchcurrent[i]) );
+
+    c_frombusshuntcurr = c_Ysh * p_branchfrombusvolt;
+    c_tobusshuntcurr = c_Ysh * p_branchtobusvolt;
+    c_branchfrombuspq = p_branchfrombusvolt * conj(c_branchcurr + c_frombusshuntcurr);
+    c_branchtobuspq = p_branchtobusvolt * conj(c_branchcurr - c_tobusshuntcurr);
+
+    p_branchfrombuspq.push_back(c_branchfrombuspq); // active power P and reactive power Q at "from" bus (P_from + j Q_from)
+    p_branchtobuspq.push_back(c_branchtobuspq); // active power P and reactive power Q at "to" bus (P_to + j Q_to)
+
+    // printf ("Branch %d element from bus apparent power, %8.4f+%8.4fj \n", i, real(p_branchfrombuspq[i]), 
+		// 	imag(p_branchfrombuspq[i]) ); 
+
+    // printf ("Branch %d element to bus apparent power, %8.4f+%8.4fj \n", i, real(p_branchtobuspq[i]), 
+		// 	imag(p_branchtobuspq[i]) );
+
+	}
 }
 
 /**

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -1293,6 +1293,13 @@ void gridpack::dynamic_simulation::DSFullBus::updateData(
 {
   int i;
   std::string name;
+  gridpack::ComplexType voltage = getComplexVoltage();
+  double rV = real(voltage);
+  double iV = imag(voltage);
+  rV = sqrt(rV*rV+iV*iV);
+  if (!data->setValue(BUS_VMAG_CURRENT, rV)) {
+    data->addValue(BUS_VMAG_CURRENT, rV);
+  }
   for (i=0; i<p_ngen; i++) {
     if (data->getValue(GENERATOR_MODEL,&name,i)) {
       p_generators[i]->updateData(data, i);

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -3588,11 +3588,9 @@ void gridpack::dynamic_simulation::DSFullBranch::load(
 }
 
 /**
- * Update data collection object with current values from simulation
- * @param data: DataCollection object containing parameters for this branch
+ * Evaluate branch flows for the to and from bus on the branch
  */
-void gridpack::dynamic_simulation::DSFullBranch::updateBranchPower(
-    boost::shared_ptr<gridpack::component::DataCollection> &data)
+void gridpack::dynamic_simulation::DSFullBranch::evaluateBranchFlow()
 {
   int i;
   double dbranchR, dbranchX;
@@ -3656,6 +3654,17 @@ void gridpack::dynamic_simulation::DSFullBranch::updateBranchPower(
     // 	imag(p_branchtobuspq[i]) );
 
   }
+}
+
+/**
+ * Update data collection object with current values from simulation
+ * @param data: DataCollection object containing parameters for this branch
+ */
+void gridpack::dynamic_simulation::DSFullBranch::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> &data)
+{
+  int i;
+  evaluateBranchFlow();
   for (i=0; i<p_elems; i++) {
     if (p_xform[i]) {
     } else {

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -1285,6 +1285,22 @@ void gridpack::dynamic_simulation::DSFullBus::load(
 }
 
 /**
+ * Update data collection object with current values from simulation
+ * @param data: DataCollection object containing parameters for this bus
+ */
+void gridpack::dynamic_simulation::DSFullBus::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> &data)
+{
+  int i;
+  for (i=0; i<p_ngen; i++) {
+    p_generators[i]->updateData(data, i);
+  }
+  for (i=0; i<p_ndyn_load; i++) {
+    p_loadmodels[i]->updateData(data, i);
+  }
+}
+
+/**
   * set voltage for the extended buses from composite load model
   */
 void gridpack::dynamic_simulation::DSFullBus::setExtendedCmplBusVoltage(
@@ -3539,6 +3555,22 @@ void gridpack::dynamic_simulation::DSFullBranch::load(
           p_linerelays.push_back(relay);	
         }  
       }
+    }
+  }
+}
+
+/**
+ * Update data collection object with current values from simulation
+ * @param data: DataCollection object containing parameters for this branch
+ */
+void gridpack::dynamic_simulation::DSFullBranch::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> &data)
+{
+  int i;
+//  gridpack::dynamic_simulation::DSFullBus *bus1 = getBus1();
+  for (i=0; i<p_elems; i++) {
+    if (p_xform[i]) {
+    } else {
     }
   }
 }

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.cpp
@@ -3698,6 +3698,7 @@ void gridpack::dynamic_simulation::DSFullBranch::updateData(
 {
   int i;
   evaluateBranchFlow();
+  updateBranchCurrent();
   for (i=0; i<p_elems; i++) {
     // Here, it does not need to differentiate transformers or lines for storing the variables.
     // Treating both transformers and lines as branches
@@ -3717,7 +3718,14 @@ void gridpack::dynamic_simulation::DSFullBranch::updateData(
     if (!data->setValue(BRANCH_TO_Q_CURRENT, qt, i)) {
       data->addValue(BRANCH_TO_Q_CURRENT, qt, i);
     }
-    
+    pf = real(p_branchcurrent[i]); 
+    qf = imag(p_branchcurrent[i]); 
+    if (!data->setValue(BRANCH_IRFLOW_CURRENT, pf, i)) {
+      data->addValue(BRANCH_IRFLOW_CURRENT, pf, i);
+    }
+    if (!data->setValue(BRANCH_IIFLOW_CURRENT, qf, i)) {
+      data->addValue(BRANCH_IIFLOW_CURRENT, qf, i);
+    }
   }
 }
 

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
@@ -946,7 +946,7 @@ class DSFullBranch
      * Update data collection object with current values from simulation
      * @param data: DataCollection object containing parameters for this branch
      */
-    void updateData(boost::shared_ptr<gridpack::component::DataCollection> &data);
+    void updateBranchPower(boost::shared_ptr<gridpack::component::DataCollection> &data);
 
     /**
      * Return the complex admittance of the branch
@@ -1115,6 +1115,9 @@ class DSFullBranch
 	std::vector<gridpack::ComplexType> p_branchcurrent; //renke add
 	gridpack::ComplexType p_branchfrombusvolt; //renke add
 	gridpack::ComplexType p_branchtobusvolt; //renke add
+
+  std::vector<gridpack::ComplexType> p_branchfrombuspq; //yuan add
+  std::vector<gridpack::ComplexType> p_branchtobuspq; //yuan add
 
   bool p_line_status_change; // Flag to indicate line status change
   gridpack::ComplexType p_yft,p_ytf; // Ybus off-diagonal contributions from this line

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
@@ -943,10 +943,15 @@ class DSFullBranch
     void load(const boost::shared_ptr<gridpack::component::DataCollection> &data);
 
     /**
+     * Evaluate branch flows for the to and from bus on the branch
+     */
+    void evaluateBranchFlow();
+
+    /**
      * Update data collection object with current values from simulation
      * @param data: DataCollection object containing parameters for this branch
      */
-    void updateBranchPower(boost::shared_ptr<gridpack::component::DataCollection> &data);
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> &data);
 
     /**
      * Return the complex admittance of the branch

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_components.hpp
@@ -243,6 +243,12 @@ class DSFullBus
      *       bus that were read in when network was initialized
      */
     void load(const boost::shared_ptr<gridpack::component::DataCollection> &data);
+
+    /**
+     * Update data collection object with current values from simulation
+     * @param data: DataCollection object containing parameters for this bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> &data);
 	
  	/**
      * load parameters for the extended buses from composite load model
@@ -935,6 +941,12 @@ class DSFullBranch
      *       branch that were read in when network was initialized
      */
     void load(const boost::shared_ptr<gridpack::component::DataCollection> &data);
+
+    /**
+     * Update data collection object with current values from simulation
+     * @param data: DataCollection object containing parameters for this branch
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> &data);
 
     /**
      * Return the complex admittance of the branch

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_factory.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_factory.cpp
@@ -729,7 +729,7 @@ void gridpack::dynamic_simulation::DSFullFactory::updateData()
   
   for (i=0; i<p_numBranch; i++) {
     data = p_network->getBranchData(i);
-    p_branches[i]->updateBranchPower(data);
+    p_branches[i]->updateData(data);
   }
 }
 

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_factory.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_factory.cpp
@@ -714,5 +714,24 @@ void gridpack::dynamic_simulation::DSFullFactory::setRTPRParams(
   }
 }
 
+/**
+ * Update data collection objects for all buses and branches with
+ * current values from simulations
+ */
+void gridpack::dynamic_simulation::DSFullFactory::updateData()
+{
+  int i;
+  boost::shared_ptr<gridpack::component::DataCollection> data;
+  for (i=0; i<p_numBus; i++) {
+    data = p_network->getBusData(i);
+    p_buses[i]->updateData(data);
+  }
+  
+  for (i=0; i<p_numBranch; i++) {
+    data = p_network->getBranchData(i);
+    p_branches[i]->updateData(data);
+  }
+}
+
 } // namespace dynamic_simulation
 } // namespace gridpack

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_factory.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_factory.cpp
@@ -729,7 +729,7 @@ void gridpack::dynamic_simulation::DSFullFactory::updateData()
   
   for (i=0; i<p_numBranch; i++) {
     data = p_network->getBranchData(i);
-    p_branches[i]->updateData(data);
+    p_branches[i]->updateBranchPower(data);
   }
 }
 

--- a/src/applications/modules/dynamic_simulation_full_y/dsf_factory.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/dsf_factory.hpp
@@ -197,6 +197,12 @@ class DSFullFactory
     void resetPower();
 
     /**
+     * Update data collection objects for all buses and branches with
+     * current values from simulations
+     */
+    void updateData();
+
+    /**
      * Set parameters for real time path rating diagnostics
      * @param src_area generation area
      * @param src_zone generation zone

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/acmotor.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/acmotor.cpp
@@ -308,6 +308,26 @@ void gridpack::dynamic_simulation::AcmotorLoad::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * load
+ * @param data collection object for bus that hosts load
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::AcmotorLoad::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+  double pl = getDynLoadP();
+  double ql = getDynLoadQ();
+  if (!data->setValue(LOAD_PL_CURRENT, pl, idx)) {
+    data->addValue(LOAD_PL_CURRENT, pl, idx);
+  }
+  if (!data->setValue(LOAD_QL_CURRENT, ql, idx)) {
+    data->addValue(LOAD_QL_CURRENT, ql, idx);
+  }
+
+}
+
+/**
  * Initialize load model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/acmotor.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/acmotor.hpp
@@ -45,6 +45,15 @@ class AcmotorLoad : public BaseLoadModel
         data, int idx, double loadP, double loadQ, int ibCMPL);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * load
+     * @param data collection object for bus that hosts load
+     * @param index of generator on bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx);
+
+    /**
      * Initialize load model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.cpp
@@ -80,6 +80,23 @@ void gridpack::dynamic_simulation::ClassicalGenerator::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * generator
+ * @param data collection object for bus that hosts generator
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::ClassicalGenerator::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+  if (!data->setValue(GENERATOR_PG_CURRENT, p_pg, idx)) {
+    data->addValue(GENERATOR_PG_CURRENT, p_pg, idx);
+  }
+  if (!data->setValue(GENERATOR_QG_CURRENT, p_qg, idx)) {
+    data->addValue(GENERATOR_QG_CURRENT, p_qg, idx);
+  }
+}
+
+/**
  * Initialize generator model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.hpp
@@ -45,6 +45,15 @@ class ClassicalGenerator : public BaseGeneratorModel
         data, int idx);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * generator
+     * @param data collection object for bus that hosts generator
+     * @param index of generator on bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx)
+
+    /**
      * Initialize generator model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/classical.hpp
@@ -51,7 +51,7 @@ class ClassicalGenerator : public BaseGeneratorModel
      * @param index of generator on bus
      */
     void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
-        int idx)
+        int idx);
 
     /**
      * Initialize generator model before calculation

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.cpp
@@ -120,6 +120,29 @@ void gridpack::dynamic_simulation::GenrouGenerator::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * generator
+ * @param data collection object for bus that hosts generator
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::GenrouGenerator::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+  if (!data->setValue(GENERATOR_PG_CURRENT, p_pg, idx)) {
+    data->addValue(GENERATOR_PG_CURRENT, p_pg, idx);
+  }
+  if (!data->setValue(GENERATOR_QG_CURRENT, p_qg, idx)) {
+    data->addValue(GENERATOR_QG_CURRENT, p_qg, idx);
+  }
+  if (p_exciter.get() != NULL) {
+    p_exciter->updateData(data, idx);
+  }
+  if (p_governor.get() != NULL) {
+    p_governor->updateData(data, idx);
+  }
+}
+
+/**
  * Saturation function
  * @ param x
  */

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/genrou.hpp
@@ -45,11 +45,20 @@ class GenrouGenerator : public BaseGeneratorModel
         data, int idx);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * generator
+     * @param data collection object for bus that hosts generator
+     * @param index of generator on bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx);
+
+    /**
      * Saturation function
      * @ param x
      */
     double Sat(double x);
-    
+
     /**
      * Initialize generator model before calculation
      * @param mag voltage magnitude

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gensal.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gensal.cpp
@@ -90,6 +90,17 @@ void gridpack::dynamic_simulation::GensalGenerator::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * generator
+ * @param data collection object for bus that hosts generator
+ * @param index of generator on bus
+ */
+    void gridpack::dynamic_simulation::GensalGenerator::updateData(
+        boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+}
+
+/**
  * Saturation function
  * @ param x
  */

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gensal.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gensal.cpp
@@ -98,6 +98,18 @@ void gridpack::dynamic_simulation::GensalGenerator::load(
     void gridpack::dynamic_simulation::GensalGenerator::updateData(
         boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
 {
+  if (!data->setValue(GENERATOR_PG_CURRENT, p_pg, idx)) {
+    data->addValue(GENERATOR_PG_CURRENT, p_pg, idx);
+  }
+  if (!data->setValue(GENERATOR_QG_CURRENT, p_qg, idx)) {
+    data->addValue(GENERATOR_QG_CURRENT, p_qg, idx);
+  }
+  if (p_exciter.get() != NULL) {
+    p_exciter->updateData(data, idx);
+  }
+  if (p_governor.get() != NULL) {
+    p_governor->updateData(data, idx);
+  }
 }
 
 /**

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/gensal.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/gensal.hpp
@@ -45,6 +45,15 @@ class GensalGenerator : public BaseGeneratorModel
         data, int idx);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * generator
+     * @param data collection object for bus that hosts generator
+     * @param index of generator on bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx);
+
+    /**
      * Saturation function
      * @ param x
      */

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/ieel.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/ieel.cpp
@@ -137,16 +137,14 @@ void gridpack::dynamic_simulation::IeelLoad::load(
  * @param data collection object for bus that hosts load
  * @param index of generator on bus
  */
-void gridpack::dynamic_simulation::AcmotorLoad::updateData(
+void gridpack::dynamic_simulation::IeelLoad::updateData(
     boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
 {
-  double pl = getDynLoadP();
-  double ql = getDynLoadQ();
-  if (!data->setValue(LOAD_PL_CURRENT, pl, idx)) {
-    data->addValue(LOAD_PL_CURRENT, pl, idx);
+  if (!data->setValue(LOAD_PL_CURRENT, P, idx)) {
+    data->addValue(LOAD_PL_CURRENT, P, idx);
   }
-  if (!data->setValue(LOAD_QL_CURRENT, ql, idx)) {
-    data->addValue(LOAD_QL_CURRENT, ql, idx);
+  if (!data->setValue(LOAD_QL_CURRENT, Q, idx)) {
+    data->addValue(LOAD_QL_CURRENT, Q, idx);
   }
 
 }

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/ieel.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/ieel.cpp
@@ -132,6 +132,26 @@ void gridpack::dynamic_simulation::IeelLoad::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * load
+ * @param data collection object for bus that hosts load
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::AcmotorLoad::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+  double pl = getDynLoadP();
+  double ql = getDynLoadQ();
+  if (!data->setValue(LOAD_PL_CURRENT, pl, idx)) {
+    data->addValue(LOAD_PL_CURRENT, pl, idx);
+  }
+  if (!data->setValue(LOAD_QL_CURRENT, ql, idx)) {
+    data->addValue(LOAD_QL_CURRENT, ql, idx);
+  }
+
+}
+
+/**
  * Initialize load model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/ieel.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/ieel.hpp
@@ -45,6 +45,15 @@ class IeelLoad : public BaseLoadModel
         data, int idx, double dloadP, double dloadQ, int ibCMPL);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * load
+     * @param data collection object for bus that hosts load
+     * @param index of generator on bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx);
+
+    /**
      * Initialize load model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.cpp
@@ -200,6 +200,26 @@ void gridpack::dynamic_simulation::MotorwLoad::load(
 }
 
 /**
+ * Update parameters in DataCollection object with current values from
+ * load
+ * @param data collection object for bus that hosts load
+ * @param index of generator on bus
+ */
+void gridpack::dynamic_simulation::AcmotorLoad::updateData(
+    boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
+{
+  double pl = getDynLoadP();
+  double ql = getDynLoadQ();
+  if (!data->setValue(LOAD_PL_CURRENT, pl, idx)) {
+    data->addValue(LOAD_PL_CURRENT, pl, idx);
+  }
+  if (!data->setValue(LOAD_QL_CURRENT, ql, idx)) {
+    data->addValue(LOAD_QL_CURRENT, ql, idx);
+  }
+
+}
+
+/**
  * Initialize load model before calculation
  * @param mag voltage magnitude
  * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.cpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.cpp
@@ -205,16 +205,14 @@ void gridpack::dynamic_simulation::MotorwLoad::load(
  * @param data collection object for bus that hosts load
  * @param index of generator on bus
  */
-void gridpack::dynamic_simulation::AcmotorLoad::updateData(
+void gridpack::dynamic_simulation::MotorwLoad::updateData(
     boost::shared_ptr<gridpack::component::DataCollection> data, int idx)
 {
-  double pl = getDynLoadP();
-  double ql = getDynLoadQ();
-  if (!data->setValue(LOAD_PL_CURRENT, pl, idx)) {
-    data->addValue(LOAD_PL_CURRENT, pl, idx);
+  if (!data->setValue(LOAD_PL_CURRENT, Pmotor, idx)) {
+    data->addValue(LOAD_PL_CURRENT, Pmotor, idx);
   }
-  if (!data->setValue(LOAD_QL_CURRENT, ql, idx)) {
-    data->addValue(LOAD_QL_CURRENT, ql, idx);
+  if (!data->setValue(LOAD_QL_CURRENT, Qmotor, idx)) {
+    data->addValue(LOAD_QL_CURRENT, Qmotor, idx);
   }
 
 }

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.hpp
@@ -45,6 +45,15 @@ class MotorwLoad : public BaseLoadModel
         data, int idx, double dloadP, double dloadQ, int ibCMPL);
 
     /**
+     * Update parameters in DataCollection object with current values from
+     * load
+     * @param data collection object for bus that hosts load
+     * @param index of generator on bus
+     */
+    void updateData(boost::shared_ptr<gridpack::component::DataCollection> data,
+        int idx);
+
+    /**
      * Initialize load model before calculation
      * @param mag voltage magnitude
      * @param ang voltage angle

--- a/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.hpp
+++ b/src/applications/modules/dynamic_simulation_full_y/model_classes/motorw.hpp
@@ -167,7 +167,7 @@ class MotorwLoad : public BaseLoadModel
     // derivatives of state variables for corrector
     double depq_dt, depd_dt, deppq_dt, deppd_dt, dslip_dt;
 
-    // oter varialbes
+    // other varialbes
     double w0, TL, Tm0, p, q, Pmotor, Qmotor, Qmotor_init, sysMVABase;
 	gridpack::ComplexType nortonImpedance_sysMVA;
 	double Fonline;

--- a/src/applications/modules/hadrec/hadrec_app_module.cpp
+++ b/src/applications/modules/hadrec/hadrec_app_module.cpp
@@ -7,7 +7,7 @@
 /**
  * @file   hadrec_app.cpp
  * @author Bruce Palmer
- * @date   2024-05-15 12:27:32 d3g096
+ * @date   2024-08-19 14:12:49 d3g096
  * 
  * @brief  
  * 
@@ -379,6 +379,18 @@ void gridpack::hadrec::HADRECAppModule::executeDynSimuOneStep(){
    
 */
 }
+
+/**
+ * Update data collection objects for all buses and branches with
+ * current values from simulations
+ */
+void gridpack::hadrec::HADRECAppModule::updateData()
+{
+  if (ds_app_sptr) {
+    ds_app_sptr->updateData();
+  }
+}
+
 
 /**
  * return observations after each simulation time step

--- a/src/applications/modules/hadrec/hadrec_app_module.hpp
+++ b/src/applications/modules/hadrec/hadrec_app_module.hpp
@@ -7,7 +7,7 @@
 /**
  * @file   hadrec_app_module.hpp
  * @author Bruce Palmer
- * @date   2024-05-22 09:32:28 d3g096
+ * @date   2024-08-19 14:09:06 d3g096
  * 
  * @brief  
  * 
@@ -106,6 +106,13 @@ class HADRECAppModule
 	* Execute only one simulation time step 
 	*/
 	void executeDynSimuOneStep();
+
+  /**
+   * Update data collection objects for all buses and branches with
+   * current values from simulations
+   */
+  void updateData();
+  
 	
 	/**
 	* Check whether the dynamic simulation is done

--- a/src/parser/variable_defs/branch_defs.hpp
+++ b/src/parser/variable_defs/branch_defs.hpp
@@ -321,4 +321,32 @@
  */
 #define BRANCH_SEQ_BI "BRANCH_SEQ_BI"
 
+/**
+ * Real power from "from" bus of branch
+ * type: real float
+ * indexed
+ */
+#define BRANCH_FROM_P_CURRENT "BRANCH_FROM_P_CURRENT"
+
+/**
+ * Reactive power from "from" bus of branch
+ * type: real float
+ * indexed
+ */
+#define BRANCH_FROM_Q_CURRENT "BRANCH_FROM_Q_CURRENT"
+
+/**
+ * Real power from "to" bus of branch
+ * type: real float
+ * indexed
+ */
+#define BRANCH_TO_P_CURRENT "BRANCH_TO_P_CURRENT"
+
+/**
+ * Reactive power from "to" bus of branch
+ * type: real float
+ * indexed
+ */
+#define BRANCH_TO_Q_CURRENT "BRANCH_TO_Q_CURRENT"
+
 #endif /* _BRANCH_VAR_HPP_ */

--- a/src/parser/variable_defs/branch_defs.hpp
+++ b/src/parser/variable_defs/branch_defs.hpp
@@ -350,31 +350,17 @@
 #define BRANCH_TO_Q_CURRENT "BRANCH_TO_Q_CURRENT"
 
 /**
- * Real branch current from "from" bus
+ * Real branch current
  * type: real float
  * indexed
  */
-#define BRANCH_FROM_IRFLOW_CURRENT "BRANCH_FROM_IRFLOW_CURRENT"
+#define BRANCH_IRFLOW_CURRENT "BRANCH_IRFLOW_CURRENT"
 
 /**
- * Imaginary branch current from "from" bus
+ * Imaginary branch current
  * type: real float
  * indexed
  */
-#define BRANCH_FROM_IIFLOW_CURRENT "BRANCH_FROM_IIFLOW_CURRENT"
-
-/**
- * Real branch current from "to" bus
- * type: real float
- * indexed
- */
-#define BRANCH_TO_IRFLOW_CURRENT "BRANCH_TO_IRFLOW_CURRENT"
-
-/**
- * Imaginary branch current from "to" bus
- * type: real float
- * indexed
- */
-#define BRANCH_TO_IIFLOW_CURRENT "BRANCH_TO_IIFLOW_CURRENT"
+#define BRANCH_IIFLOW_CURRENT "BRANCH_IIFLOW_CURRENT"
 
 #endif /* _BRANCH_VAR_HPP_ */

--- a/src/parser/variable_defs/branch_defs.hpp
+++ b/src/parser/variable_defs/branch_defs.hpp
@@ -19,6 +19,12 @@
  *  index are denoted with the keyword "indexed".
  */
 
+/**
+ * Variables that have _CURRENT appended to them may be added to the data
+ * collection during runtime and updated as the simulation
+ * proceeds
+ */
+
 #ifndef _BRANCH_VAR_HPP_
 #define _BRANCH_VAR_HPP_
 

--- a/src/parser/variable_defs/branch_defs.hpp
+++ b/src/parser/variable_defs/branch_defs.hpp
@@ -349,4 +349,32 @@
  */
 #define BRANCH_TO_Q_CURRENT "BRANCH_TO_Q_CURRENT"
 
+/**
+ * Real branch current from "from" bus
+ * type: real float
+ * indexed
+ */
+#define BRANCH_FROM_IRFLOW_CURRENT "BRANCH_FROM_IRFLOW_CURRENT"
+
+/**
+ * Imaginary branch current from "from" bus
+ * type: real float
+ * indexed
+ */
+#define BRANCH_FROM_IIFLOW_CURRENT "BRANCH_FROM_IIFLOW_CURRENT"
+
+/**
+ * Real branch current from "to" bus
+ * type: real float
+ * indexed
+ */
+#define BRANCH_TO_IRFLOW_CURRENT "BRANCH_TO_IRFLOW_CURRENT"
+
+/**
+ * Imaginary branch current from "to" bus
+ * type: real float
+ * indexed
+ */
+#define BRANCH_TO_IIFLOW_CURRENT "BRANCH_TO_IIFLOW_CURRENT"
+
 #endif /* _BRANCH_VAR_HPP_ */

--- a/src/parser/variable_defs/bus_defs.hpp
+++ b/src/parser/variable_defs/bus_defs.hpp
@@ -76,6 +76,7 @@
  * type: real float
  */
 #define BUS_VOLTAGE_MAG "BUS_VOLTAGE_MAG"
+#define BUS_VMAG_CURRENT "BUS_VMAG_CURRENT"
 
 /**
  * Bus voltage phase angle, in degrees

--- a/src/parser/variable_defs/generator_defs.hpp
+++ b/src/parser/variable_defs/generator_defs.hpp
@@ -94,7 +94,7 @@
  * indexed
  */
 #define GENERATOR_VS "GENERATOR_VS"
-#define GENERATOR_VS "GENERATOR_VS_CURRENT"
+#define GENERATOR_VS_CURRENT "GENERATOR_VS_CURRENT"
 
 /**
  * Bus number of a remote type 1 or 2 bus whose voltage is to be regulated by this plant to the

--- a/src/parser/variable_defs/generator_defs.hpp
+++ b/src/parser/variable_defs/generator_defs.hpp
@@ -19,6 +19,13 @@
  *  index are denoted with the keyword "indexed".
  */
 
+
+/**
+ * Variables that have _CURRENT appended to them may be added to the data
+ * collection during runtime and updated as the simulation
+ * proceeds
+ */
+
 #ifndef _GENERATOR_VAR_HPP_
 #define _GENERATOR_VAR_HPP_
 
@@ -57,6 +64,7 @@
  * indexed
  */
 #define GENERATOR_PG "GENERATOR_PG"
+#define GENERATOR_PG "GENERATOR_PG_CURRENT"
 
 /**
  * Generator reactive power output, entered in MVar
@@ -64,6 +72,7 @@
  * indexed
  */
 #define GENERATOR_QG "GENERATOR_QG"
+#define GENERATOR_QG "GENERATOR_QG_CURRENT"
 
 /**
  * Maximum generator reactive power output; entered in Mvar
@@ -85,6 +94,7 @@
  * indexed
  */
 #define GENERATOR_VS "GENERATOR_VS"
+#define GENERATOR_VS "GENERATOR_VS_CURRENT"
 
 /**
  * Bus number of a remote type 1 or 2 bus whose voltage is to be regulated by this plant to the
@@ -1431,5 +1441,12 @@
  * indexed
  */
 #define GENERATOR_MODEL "GENERATOR_MODEL"
+
+/**
+ * Nominal power of the generator
+ * type: float
+ * indexed
+ */
+#define GENERATOR_NOM_POWER_CURRENT "GENERATOR_NOM_POWER_CURRENT"
 
 #endif /* _GENERATOR_VAR_HPP_ */

--- a/src/parser/variable_defs/generator_defs.hpp
+++ b/src/parser/variable_defs/generator_defs.hpp
@@ -64,7 +64,7 @@
  * indexed
  */
 #define GENERATOR_PG "GENERATOR_PG"
-#define GENERATOR_PG "GENERATOR_PG_CURRENT"
+#define GENERATOR_PG_CURRENT "GENERATOR_PG_CURRENT"
 
 /**
  * Generator reactive power output, entered in MVar
@@ -72,7 +72,7 @@
  * indexed
  */
 #define GENERATOR_QG "GENERATOR_QG"
-#define GENERATOR_QG "GENERATOR_QG_CURRENT"
+#define GENERATOR_QG_CURRENT "GENERATOR_QG_CURRENT"
 
 /**
  * Maximum generator reactive power output; entered in Mvar

--- a/src/parser/variable_defs/load_defs.hpp
+++ b/src/parser/variable_defs/load_defs.hpp
@@ -82,7 +82,7 @@
  * indexed
  */
 #define LOAD_PL "LOAD_PL"
-#define LOAD_PL "LOAD_PL_CURRENT"
+#define LOAD_PL_CURRENT "LOAD_PL_CURRENT"
 
 /**
  * Reactive power component of constant power load; entered in MVar
@@ -90,7 +90,7 @@
  * indexed
  */
 #define LOAD_QL "LOAD_QL"
-#define LOAD_QL "LOAD_QL_CURRENT"
+#define LOAD_QL_CURRENT "LOAD_QL_CURRENT"
 
 /**
  * Active power component of constant current load; entered in MW 

--- a/src/parser/variable_defs/load_defs.hpp
+++ b/src/parser/variable_defs/load_defs.hpp
@@ -19,6 +19,13 @@
  *  index are denoted with the keyword "indexed".
  */
 
+/**
+ * Variables that have _CURRENT appended to them may be added to the data
+ * collection during runtime and updated as the simulation
+ * proceeds
+ */
+
+
 #ifndef _LOAD_VAR_HPP_
 #define _LOAD_VAR_HPP_
 
@@ -75,6 +82,7 @@
  * indexed
  */
 #define LOAD_PL "LOAD_PL"
+#define LOAD_PL "LOAD_PL_CURRENT"
 
 /**
  * Reactive power component of constant power load; entered in MVar
@@ -82,6 +90,7 @@
  * indexed
  */
 #define LOAD_QL "LOAD_QL"
+#define LOAD_QL "LOAD_QL_CURRENT"
 
 /**
  * Active power component of constant current load; entered in MW 

--- a/src/parser/variable_defs/transformer_defs.hpp
+++ b/src/parser/variable_defs/transformer_defs.hpp
@@ -19,6 +19,12 @@
  *  index are denoted with the keyword "indexed".
  */
 
+/**
+ * Variables that have _CURRENT appended to them may be added to the data
+ * collection during runtime and updated as the simulation
+ * proceeds
+ */
+
 #ifndef _TRANSFORMER_VAR_HPP_
 #define _TRANSFORMER_VAR_HPP_
 


### PR DESCRIPTION
This provides a way to store and query the state of dynamic simulations using the network's `DataCollection` objects.  This provides a consistent API to move simulation results to `DataCollection` objects and query those values.  This API has been added to the Dynamic Simulation and HADREC application modules, including Python interfaces. 

Resolves #214.
