### PR TITLE
Updates to use Global Arrays 5.9

### DIFF
--- a/install_gridpack.sh
+++ b/install_gridpack.sh
@@ -11,7 +11,7 @@ install_gridpack_python=true
 
 # These must match install_gridpack_deps.sh
 boost_version="1.81.0"
-ga_version="5.8.2"
+ga_version="5.9"
 
 if "$install_gridpack_python"; then
     install_gridpack_shared=true
@@ -76,6 +76,7 @@ then
    -D MPIEXEC:STRING='mpiexec' 
    -D MPIEXEC_MAX_NUMPROCS:STRING=2
    -D GRIDPACK_TEST_TIMEOUT:STRING=120 
+   -D ENABLE_ENVIRONMENT_FROM_COMM:BOOL=YES 
    -D CMAKE_INSTALL_PREFIX:PATH=${GRIDPACK_INSTALL_DIR} 
    -D CMAKE_BUILD_TYPE:STRING=Debug 
    -D BUILD_SHARED_LIBS=$install_gridpack_shared 

--- a/install_gridpack_deps.sh
+++ b/install_gridpack_deps.sh
@@ -92,7 +92,7 @@ then
       gashopts="--enable-shared=no --enable-static=yes"
   fi
 
-  ga_version="5.8.2"
+  ga_version="5.9"
   echo "Downloading GA-$ga_version"
 
   wget "https://github.com/GlobalArrays/ga/releases/download/v${ga_version}/ga-${ga_version}.tar.gz"
@@ -187,6 +187,27 @@ export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 cd ${GRIDPACK_ROOT_DIR}
 
+# Write important variables to a script file that can be used to
+# restore this environment later
+
+envbash="${GRIDPACK_ROOT_DIR}/gridpack_env.sh"
+envcsh="${GRIDPACK_ROOT_DIR}/gridpack_env.csh"
+savevars="\
+    GRIDPACK_ROOT_DIR \
+    GP_EXT_DEPS \
+    LD_LIBRARY_PATH \
+    DYLD_LIBRARY_PATH \
+"
+
+echo "# GridPACK dependency environment variables" > "$envbash"
+echo "# GridPACK dependency environment variables" > "$envcsh"
+
+for var in $savevars; do
+    echo "export $var=${!var}" >> "$envbash"
+    echo "setenv $var ${!var}" >> "$envcsh"
+done
+
 echo "Completed installing GridPACK dependencies in ${GP_EXT_DEPS}"
+echo "Restore environment with \". $envbash\" or \"source $envcsh\""
 
 set +x

--- a/src/example_configuration.sh
+++ b/src/example_configuration.sh
@@ -242,16 +242,15 @@ elif [ $host == "tlaloc" ]; then
     #      -D PETSC_ARCH:STRING="ubuntu-real-shared-debug" \
 
     if [ -z "$GRIDPACK_DIR" ]; then
-        prefix="$HOME/Projects/ExaLearn/gridpack-install"
+        prefix="$HOME/Projects/GridPACK-Wind/gridpack-install"
     else
         prefix="$GRIDPACK_DIR"
     fi
     
-    prefix="$HOME/Projects/GridPACK-Wind/gridpack-install"
     cmake -Wdev --debug-trycompile \
-        --graphviz=GridPACK.dot \
-          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.21.6" \
-          -D PETSC_ARCH:STRING="ubuntu-real-shared-debug" \
+          --graphviz=GridPACK.dot \
+          -D PETSC_DIR:STRING="/home/d3g096/Projects/GridPakLDRD/petsc-3.20.6" \
+          -D PETSC_ARCH:STRING="ubuntu-complex-shared" \
           -D Boost_ROOT:PATH="/usr" \
           -D PARMETIS_DIR:PATH="/usr" \
           -D MPI_CXX_COMPILER:STRING="mpicxx" \


### PR DESCRIPTION
[Global Arrays 5.9](https://github.com/GlobalArrays/ga/releases/tag/v5.9) has been released.  This version includes the ability to use an externally created `MPI_Comm` to initialize GA.  GridPACK has been able to utilize this feature for some time.  Since this feature is now official, build scripts and the GA submodule are updated to use the new 5.9 version.  