### PR TITLE
Updates to fix error on multiple cores

### DIFF
--- a/src/applications/modules/emt/base_classes/base_gen_model.cpp
+++ b/src/applications/modules/emt/base_classes/base_gen_model.cpp
@@ -54,6 +54,12 @@ void BaseEMTGenModel::load(const boost::shared_ptr<gridpack::component::DataColl
     data->getValue(GENERATOR_QG,&qg,idx); // Generator reactive power
     pg *= sbase;
     qg *= sbase;
+    double sg = sqrt(pg*pg + qg*qg);
+    if(sg > mbase) {
+      printf("Bus number %d generator id %s has Sg %.17g greater than mbase %.17g\n",busnum,id.c_str(),sg,mbase);
+      printf("Increasing mbase to 1.5*sg\n");
+      mbase = 1.5*sg;
+    }
   } else {
     pg = qg;
   }

--- a/src/applications/modules/emt/cblock.cpp
+++ b/src/applications/modules/emt/cblock.cpp
@@ -6,6 +6,8 @@ Cblock::Cblock()
   p_order = 1; // For future use
   p_xmin  = p_ymin = p_dxmin = -1000.0;
   p_xmax  = p_ymax = p_dxmax =  1000.0;
+  x[0] = 0.0;
+  p_dxdt[0] = 0.0;
   strcpy(name,"cblock");
 }
 
@@ -64,18 +66,18 @@ void Cblock::updatestate(double u,double dt,double xmin,double xmax,double dxmin
 
   dx_dt = getderivative(x[0],u);
   if(dx_dt < p_dxmin) {
-    printf("Block %s state derivative %lf out of min. bounds %lf\n",name,dx_dt,p_dxmin);
+    printf("Block %s state derivative %.17g out of min. bounds %.17g\n",name,dx_dt,p_dxmin);
   } else if(dx_dt > p_dxmax) {
-    printf("Block %s state derivative %lf out of max. bounds %lf\n",name,dx_dt,p_dxmax);
+    printf("Block %s state derivative %.17g out of max. bounds %.17g\n",name,dx_dt,p_dxmax);
   }
 
   p_dxdt[0] = std::max(p_dxmin,std::min(dx_dt,p_dxmax));
   xout = x[0] + dt*p_dxdt[0];
 
   if(xout < xmin) {
-    printf("Block %s state %lf out of min. bounds %lf\n",name,xout,xmin);
+    printf("Block %s state %.17g out of min. bounds %.17g\n",name,xout,xmin);
   } else if(xout > xmax) {
-    printf("Block %s state %lf out of max. bounds %lf\n",name,xout,xmax);
+    printf("Block %s state %.17g out of max. bounds %.17g\n",name,xout,xmax);
   }
 
   
@@ -98,9 +100,9 @@ double Cblock::getoutput(double u)
   y_n = p_C[0]*x_n + p_D[0]*u;
 
   if(y_n < p_ymin) {
-    printf("Block %s output %lf out of min. bounds %lf\n",name,y_n,p_ymin);
+    printf("Block %s output %.17g out of min. bounds %.17g\n",name,y_n,p_ymin);
   } else if(y_n > p_ymax) {
-    printf("Block %s output %lf out of max. bounds %lf\n",name,y_n,p_ymax);
+    printf("Block %s output %.17g out of max. bounds %.17g\n",name,y_n,p_ymax);
   }
 
 
@@ -111,7 +113,7 @@ double Cblock::getoutput(double u)
   
 double Cblock::getoutput(double u,double dt,double xmin,double xmax,double ymin,double ymax,bool dostateupdate)
 {
-  double x_n,y_n=0.0,x_n1;
+  double x_n,y_n=0.0;
 
   x_n = x[0];
   
@@ -173,15 +175,15 @@ double Cblock::init_given_u(double u)
     y    = p_C[0]*x[0] + p_D[0]*u;
   }
   if(x[0] < p_xmin) {
-    printf("Block %s initial state %lf out of min. bounds %lf\n",name,x[0],p_xmin);
+    printf("Block %s initial state %.17g out of min. bounds %.17g\n",name,x[0],p_xmin);
   } else if(x[0] > p_xmax) {
-    printf("Block %s initial state %lf out of max. bounds %lf\n",name,x[0],p_xmax);
+    printf("Block %s initial state %.17g out of max. bounds %.17g\n",name,x[0],p_xmax);
   }
 
   if(y < p_ymin) {
-    printf("Block %s initial output %lf out of min. bounds %lf\n",name,y,p_ymin);
+    printf("Block %s initial output %.17g out of min. bounds %.17g\n",name,y,p_ymin);
   } else if(y > p_ymax) {
-    printf("Block %s initial output %lf out of max. bounds %lf\n",name,y,p_ymax);
+    printf("Block %s initial output %.17g out of max. bounds %.17g\n",name,y,p_ymax);
   }
   
   return y;
@@ -199,15 +201,15 @@ double Cblock::init_given_y(double y)
   }
 
   if(x[0] < p_xmin) {
-    printf("Block %s initial state %lf out of min. bounds %lf\n",name,x[0],p_xmin);
+    printf("Block %s initial state %.17g out of min. bounds %.17g\n",name,x[0],p_xmin);
   } else if(x[0] > p_xmax) {
-    printf("Block %s initial state %lf out of max. bounds %lf\n",name,x[0],p_xmax);
+    printf("Block %s initial state %.17g out of max. bounds %.17g\n",name,x[0],p_xmax);
   }
 
   if(y < p_ymin) {
-    printf("Block %s initial output %lf out of min. bounds %lf\n",name,y,p_ymin);
+    printf("Block %s initial output %.17g out of min. bounds %.17g\n",name,y,p_ymin);
   } else if(y > p_ymax) {
-    printf("Block %s initial output %lf out of max. bounds %lf\n",name,y,p_ymax);
+    printf("Block %s initial output %.17g out of max. bounds %.17g\n",name,y,p_ymax);
   }
   
   return u;

--- a/src/applications/modules/emt/emtnetwork.cpp
+++ b/src/applications/modules/emt/emtnetwork.cpp
@@ -1677,6 +1677,8 @@ void EmtBus::vectorGetElementValues(gridpack::RealType *values, int *idx)
     for(i=0; i < p_ngen; i++) {
       if(!p_gen[i]->getStatus()) continue;
 
+      //printf("Bus number: %d\n",p_busnum);
+	    
       p_gen[i]->setVoltage(v[0],v[1],v[2]);
       p_gen[i]->setTime(p_time);
 

--- a/src/applications/modules/emt/model_classes/genrou.cpp
+++ b/src/applications/modules/emt/model_classes/genrou.cpp
@@ -211,7 +211,7 @@ bool Genrou::serialWrite(char *string, const int bufsize,const char *signal)
     Pgen = p_online*(vdq0[0]*idq0[0] + vdq0[1]*idq0[1])*mbase/sbase;
     Qgen = p_online*(vdq0[1]*idq0[0] - vdq0[0]*idq0[1])*mbase/sbase;
 
-    sprintf(string,", %6.5f,%6.5f,%6.5f,%6.5f,%6.5f",Vm,Pgen,Qgen,delta,dspd);
+    sprintf(string,", %.17g,%.17g,%.17g,%.17g,%.17g",Vm,Pgen,Qgen,delta,dspd);
     return true;
   }
   return false;

--- a/src/applications/modules/emt/model_classes/reeca1.cpp
+++ b/src/applications/modules/emt/model_classes/reeca1.cpp
@@ -216,6 +216,9 @@ void Reeca1::init(gridpack::RealType* xin)
   Verr_PI_blk.setname(Verr_PI_blk_name.c_str());
   Verr_PI_blk.setparams(Kvp,Kvi);
   // Iq lag block
+  std::string Iq_lag_blk_name = blkhead + "Iq_lag_blk";
+  Iq_lag_blk.setname(Iq_lag_blk_name.c_str());
+
   Iq_lag_blk.setparams(1.0,Tiq);
 
   // Vt filter output used in division

--- a/src/applications/modules/emt/model_classes/regca1.cpp
+++ b/src/applications/modules/emt/model_classes/regca1.cpp
@@ -60,11 +60,19 @@ void Regca1::init(gridpack::RealType* xin)
   double Vr, Vi;
 
   // Set up blocks
+  /* Create string for setting name */
+  std::string blkhead = std::to_string(busnum) + "_" + id + "REGCA1_";
+
 
   // transfer function blocks
+  std::string Ip_blk_name = blkhead + "Ip_blk";
+  Ip_blk.setname(Ip_blk_name.c_str());
   Ip_blk.setparams(1.0,tg);
-  
+
+  std::string Iq_blk_name = blkhead + "Iq_blk";
+  Iq_blk.setname(Iq_blk_name.c_str());
   Iq_blk.setparams(-1.0,tg);
+  
   if(qg > 0.0) {
     // Upper limit active with Qg > 0
     Iq_blk.setdxlimits(-1000.0,iqrmax);
@@ -72,6 +80,9 @@ void Regca1::init(gridpack::RealType* xin)
     // Lower limit active when Qg < 0
     Iq_blk.setdxlimits(iqrmin,1000.0);
   }
+
+  std::string Vt_filter_blk_name = blkhead + "Vt_filter_blk";
+  Vt_filter_blk.setname(Vt_filter_blk_name.c_str());
   Vt_filter_blk.setparams(1.0,tfltr);
 
   double u[2],y[2];

--- a/src/applications/modules/emt/model_classes/regca1.cpp
+++ b/src/applications/modules/emt/model_classes/regca1.cpp
@@ -179,7 +179,7 @@ bool Regca1::serialWrite(char *string, const int bufsize,const char *signal)
     else dspd = 0.0;
     
     getPower(p_time,&Pgen,&Qgen);
-    sprintf(string,", %6.5f,%6.5f,%6.5f,%6.5f,%6.5f",Vt_filter,Pgen*mbase/sbase,Qgen*mbase/sbase,delta,dspd);
+    sprintf(string,", %.17g,%.17g,%.17g,%.17g,%.17g",Vt_filter,Pgen*mbase/sbase,Qgen*mbase/sbase,delta,dspd);
     return true;
   }
   return false;

--- a/src/applications/modules/emt/model_classes/tgov1.cpp
+++ b/src/applications/modules/emt/model_classes/tgov1.cpp
@@ -117,8 +117,11 @@ void Tgov1::init(gridpack::RealType* xin)
     /* Create string for setting name */
     std::string blkhead = std::to_string(busnum) + "_" + id + "TGOV1_";
 
-    leadlag_blk.setparams(T2,T3);
 
+    std::string leadlag_block_name = blkhead + "leadlag_blk";
+    leadlag_blk.setname(leadlag_block_name.c_str());
+    leadlag_blk.setparams(T2,T3);
+    
     std::string delay_block_name = blkhead + "delay_blk";
     delay_blk.setname(delay_block_name.c_str());
     delay_blk.setparams(1.0,T1,Vmin,Vmax,-1000.0,1000.0);


### PR DESCRIPTION
- Initialize variables in Cblock to fix error seen on multiple cores
- Use %.17g to print the full double precision value of variables in serial I/O