### PR TITLE
Add Python interface docs to user manual

### DIFF
--- a/docs/python/Makefile
+++ b/docs/python/Makefile
@@ -5,6 +5,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = python /usr/share/sphinx/scripts/python3/sphinx-build
+SPHINXBUILD   = sphinx-build
 PAPER         = letter
 BUILDDIR      = _build
 
@@ -72,6 +73,12 @@ man:
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+
+.PHONY: rst
+rst:
+	$(SPHINXBUILD) -b rst $(ALLSPHINXOPTS) $(BUILDDIR)/rst
+	@echo
+	@echo "Build finished. The rst pages are in $(BUILDDIR)/rst."
 
 .PHONY: doctest
 doctest:

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -1,0 +1,35 @@
+# GridPACK Python Documentation #
+
+## Documentation Generation ##
+
+This is the Sphinx-based documentation for the GridPACK Python
+interface.  It is auto-generated, but the `gridpack` module must be
+available to Python when it is generated.  It's best to create a
+virtual Python environment to provide compatible Sphinx and GridPACK
+modules.  At the time of writing, the following Sphinx module are
+required:
+
+```
+pip install sphinx
+pip intall sphinxcontrib-restbuilder
+pip install sphinx_rtd_theme
+pip install sphinx_subfigure
+```
+
+The GridPACK module should also be installed in the environment.  
+
+
+## Incorporate into Manual Documentation ## 
+
+  * Generate Python interface documentation in RST format:
+
+    ```
+    make rst
+    ```
+  * Copy the generated files in `_build/rst`, except `index.rst`, into
+    the user manual documentation tree.  
+  * In the user manual document source, modify `python/index.rst` if
+    files have been added. Add any new files to the GIT repository.
+  * Generate the user manual in HTML format and check.
+
+

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -11,7 +11,7 @@ required:
 
 ```
 pip install sphinx
-pip intall sphinxcontrib-restbuilder
+pip isntall sphinxcontrib-restbuilder
 pip install sphinx_rtd_theme
 pip install sphinx_subfigure
 ```

--- a/docs/python/conf.py
+++ b/docs/python/conf.py
@@ -27,10 +27,8 @@
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon',
-]
+    'sphinxcontrib.restbuilder',
+ ]
 
 autosummary_generate = True
 
@@ -111,7 +109,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/user_manual/sphinx/conf.py
+++ b/docs/user_manual/sphinx/conf.py
@@ -101,7 +101,7 @@ html_logo = 'logo.svg'
 html_theme_options = {
     'logo_only': True,
     'display_version': False,
-}`
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/user_manual/sphinx/index.rst
+++ b/docs/user_manual/sphinx/index.rst
@@ -4,6 +4,7 @@ GridPACK documentation
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   :name: mastertoc
 
    Section0-GridPACK
    Section1-Introduction
@@ -15,3 +16,10 @@ GridPACK documentation
    Section7-GeneralizedMatVecInterface
    Section8-ApplicationModules
    Section9-Examples
+
+.. toctree::
+   :maxdepth: 1
+   :name: mastertoc2
+
+   python/index
+          

--- a/docs/user_manual/sphinx/python/dynamic_simulation.rst
+++ b/docs/user_manual/sphinx/python/dynamic_simulation.rst
@@ -1,0 +1,445 @@
+
+Dynamic Simulation
+******************
+
+
+Reference
+=========
+
+GridPACK Dynamic Simulation Application module
+
+**class gridpack.dynamic_simulation.DSFullApp**
+
+   **applyConstYLoadShedding(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: float) ->
+   None**
+
+   **applyConstYLoad_Change_P(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: float) ->
+   None**
+
+   **applyConstYLoad_Change_Q(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: float) ->
+   None**
+
+   **applyGFIAdjustment(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int, arg1: int, arg2: str, arg3: float) -> None**
+
+   **applyGeneratorTripping(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str) ->
+   None**
+
+   **applyLoadShedding(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int, arg1: str, arg2: float) -> None**
+
+   **clearConstYLoad_Change_P(self:
+   gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **clearConstYLoad_Change_Q(self:
+   gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **clearLineTripAction(self: gridpack.dynamic_simulation.DSFullApp)
+   -> None**
+
+   **close(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **executeOneSimuStep(self: gridpack.dynamic_simulation.DSFullApp)
+   -> None**
+
+   **frequencyOK(self: gridpack.dynamic_simulation.DSFullApp) ->
+   bool**
+
+   **getBranchEndpoints(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int) -> tuple**
+
+   **getBranchInfoBool(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBranchInfoInt(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBranchInfoReal(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBranchInfoString(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoBool(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   int, arg1: str, arg2: int | None) -> object**
+
+   **getBusInfoInt(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoReal(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoString(self: gridpack.dynamic_simulation.DSFullApp,
+   bus_idx: int, name: str, dev_idx: int | None = -1) -> object**
+
+   **getBusTotalLoadPower(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int) -> object**
+
+   **getConnectedBranches(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int) -> list[int]**
+
+   **getCurrentTime(self: gridpack.dynamic_simulation.DSFullApp) ->
+   float**
+
+   **getEvents(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. getEvents(self: gridpack.dynamic_simulation.DSFullApp) ->
+         gridpack.dynamic_simulation.EventVector
+
+      2. getEvents(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+         gridpack.ConfigurationCursor) ->
+         gridpack.dynamic_simulation.EventVector
+
+   **getFinalTime(self: gridpack.dynamic_simulation.DSFullApp) ->
+   float**
+
+   **getFrequencyFailures(self: gridpack.dynamic_simulation.DSFullApp)
+   -> list[int]**
+
+   **getGeneratorMargins(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int, arg1: int) -> object**
+
+   **getGeneratorPower(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int, arg1: str) -> object**
+
+   **getGeneratorTimeSeries(self:
+   gridpack.dynamic_simulation.DSFullApp) -> list[list[float]]**
+
+   **getListWatchedGenerators(self:
+   gridpack.dynamic_simulation.DSFullApp) -> object**
+
+   **getObservationLists(self: gridpack.dynamic_simulation.DSFullApp)
+   -> object**
+
+   **getObservationLists_withBusFreq(self:
+   gridpack.dynamic_simulation.DSFullApp) -> object**
+
+   **getObservations(self: gridpack.dynamic_simulation.DSFullApp) ->
+   object**
+
+   **getObservations_withBusFreq(self:
+   gridpack.dynamic_simulation.DSFullApp) -> object**
+
+   **getState(self: gridpack.dynamic_simulation.DSFullApp, arg0: int,
+   arg1: str, arg2: str, arg3: str) -> object**
+
+   **getTimeSeriesMap(self: gridpack.dynamic_simulation.DSFullApp) ->
+   list[int]**
+
+   **getTimeStep(self: gridpack.dynamic_simulation.DSFullApp) ->
+   float**
+
+   **getTotalLoadRealPower(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: int) ->
+   float**
+
+   **getZoneGeneratorPower(self:
+   gridpack.dynamic_simulation.DSFullApp) -> object**
+
+   **getZoneLoads(self: gridpack.dynamic_simulation.DSFullApp) ->
+   object**
+
+   **initialize(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **isDynSimuDone(self: gridpack.dynamic_simulation.DSFullApp) ->
+   bool**
+
+   **isSecure(self: gridpack.dynamic_simulation.DSFullApp) -> int**
+
+   **modifyDataCollectionBusParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionBusParam(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str,
+         arg2: float) -> bool
+
+      2. modifyDataCollectionBusParam(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str,
+         arg2: int) -> bool
+
+   **modifyDataCollectionGenParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionGenParam(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str,
+         arg2: str, arg3: float) -> bool
+
+      2. modifyDataCollectionGenParam(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str,
+         arg2: str, arg3: int) -> bool
+
+   **modifyDataCollectionLoadParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionLoadParam(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str,
+         arg2: str, arg3: float) -> bool
+
+      2. modifyDataCollectionLoadParam(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str,
+         arg2: str, arg3: int) -> bool
+
+   **numGenerators(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numGenerators(self: gridpack.dynamic_simulation.DSFullApp) ->
+         int
+
+      2. numGenerators(self: gridpack.dynamic_simulation.DSFullApp,
+         arg0: int) -> int
+
+   **numLines(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numLines(self: gridpack.dynamic_simulation.DSFullApp) -> int
+
+      2. numLines(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+         int) -> int
+
+   **numLoads(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numLoads(self: gridpack.dynamic_simulation.DSFullApp) -> int
+
+      2. numLoads(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+         int) -> int
+
+   **numStorage(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numStorage(self: gridpack.dynamic_simulation.DSFullApp) ->
+         int
+
+      2. numStorage(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+         int) -> int
+
+   **open(self: gridpack.dynamic_simulation.DSFullApp, arg0: str) ->
+   None**
+
+   **print(self: gridpack.dynamic_simulation.DSFullApp, arg0: str) ->
+   None**
+
+   **readGenerators(self: gridpack.dynamic_simulation.DSFullApp,
+   ds_idx: int = -1) -> None**
+
+   **readSequenceData(self: gridpack.dynamic_simulation.DSFullApp) ->
+   None**
+
+   **reload(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **reset(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **resetPower(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **run(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. run(self: gridpack.dynamic_simulation.DSFullApp) -> None
+
+      2. run(self: gridpack.dynamic_simulation.DSFullApp, arg0: float)
+         -> None
+
+   **saveTimeSeries(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   bool) -> None**
+
+   **scaleGeneratorRealPower(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: float, arg1: int,
+   arg2: int) -> None**
+
+   **scaleLoadPower(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   float, arg1: int, arg2: int) -> None**
+
+   **scatterInjectionLoad(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: list[int], arg1: list[float], arg2: list[float]) -> None**
+
+   **scatterInjectionLoadNew(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: list[int], arg1:
+   list[float], arg2: list[float]) -> None**
+
+   **scatterInjectionLoadNewConstCur(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: list[int], arg1:
+   list[float], arg2: list[float]) -> None**
+
+   **scatterInjectionLoadNew_Norton(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: list[int], arg1:
+   list[float], arg2: list[float], arg3: list[float], arg4:
+   list[float]) -> None**
+
+   **scatterInjectionLoadNew_compensateY(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: list[int], arg1:
+   list[float], arg2: list[float]) -> None**
+
+   **setConstYLoadImpedance(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: float,
+   arg2: float) -> None**
+
+   **setConstYLoadtoZero_P(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int) -> None**
+
+   **setConstYLoadtoZero_Q(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int) -> None**
+
+   **setEvent(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   gridpack.dynamic_simulation.Event) -> None**
+
+   **setFinalTime(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   float) -> None**
+
+   **setFrequencyMonitoring(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: bool, arg1: float) ->
+   None**
+
+   **setGeneratorWatch(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. setGeneratorWatch(self:
+         gridpack.dynamic_simulation.DSFullApp) -> None
+
+      2. setGeneratorWatch(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: str) -> None
+
+      3. setGeneratorWatch(self:
+         gridpack.dynamic_simulation.DSFullApp, buses: list[int] = [],
+         tags: list[str] = [], writeFile: bool = True) -> None
+
+      4. setGeneratorWatch(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: str, arg1:
+         gridpack.ConfigurationCursor) -> None
+
+      5. setGeneratorWatch(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0:
+         gridpack.ConfigurationCursor) -> None
+
+   **setLineTripAction(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. setLineTripAction(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: int,
+         arg2: str) -> None
+
+      2. setLineTripAction(self:
+         gridpack.dynamic_simulation.DSFullApp, arg0: int) -> None
+
+   **setLoadWatch(self: gridpack.dynamic_simulation.DSFullApp) ->
+   None**
+
+   **setObservations(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: gridpack.ConfigurationCursor) -> None**
+
+   **setState(self: gridpack.dynamic_simulation.DSFullApp, arg0: int,
+   arg1: str, arg2: str, arg3: str, arg4: float) -> bool**
+
+   **setTimeStep(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   float) -> None**
+
+   **setWideAreaControlSignal(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: int, arg1: str, arg2:
+   float) -> None**
+
+   **setup(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **solve(self: gridpack.dynamic_simulation.DSFullApp, arg0:
+   gridpack.dynamic_simulation.Event) -> None**
+
+   **solvePowerFlowBeforeDynSimu(self:
+   gridpack.dynamic_simulation.DSFullApp, arg0: str, arg1: int) ->
+   None**
+
+   **solvePreInitialize(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: gridpack.dynamic_simulation.Event) -> None**
+
+   **totalBranches(self: gridpack.dynamic_simulation.DSFullApp) ->
+   int**
+
+   **totalBuses(self: gridpack.dynamic_simulation.DSFullApp) -> int**
+
+   **updateData(self: gridpack.dynamic_simulation.DSFullApp) -> None**
+
+   **write(self: gridpack.dynamic_simulation.DSFullApp, arg0: str) ->
+   None**
+
+   **writeRTPRDiagnostics(self: gridpack.dynamic_simulation.DSFullApp,
+   arg0: int, arg1: int, arg2: int, arg3: int, arg4: float, arg5:
+   float, arg6: str) -> None**
+
+**class gridpack.dynamic_simulation.Event**
+
+   ``property bus_idx``
+
+   ``property end``
+
+   ``property from_idx``
+
+   ``property isBus``
+
+   ``property isGenerator``
+
+   ``property isLine``
+
+   ``property start``
+
+   ``property step``
+
+   ``property tag``
+
+   ``property to_idx``
+
+**class gridpack.dynamic_simulation.EventVector**
+
+   **append(self: gridpack.dynamic_simulation.EventVector, x:
+   gridpack::dynamic_simulation::Event) -> None**
+
+      Add an item to the end of the list
+
+   **clear(self: gridpack.dynamic_simulation.EventVector) -> None**
+
+      Clear the contents
+
+   **extend(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. extend(self: gridpack.dynamic_simulation.EventVector, L:
+         gridpack.dynamic_simulation.EventVector) -> None
+
+      Extend the list by appending all the items in the given list
+
+      1. extend(self: gridpack.dynamic_simulation.EventVector, L:
+         Iterable) -> None
+
+      Extend the list by appending all the items in the given list
+
+   **insert(self: gridpack.dynamic_simulation.EventVector, i: int, x:
+   gridpack::dynamic_simulation::Event) -> None**
+
+      Insert an item at a given position.
+
+   **pop(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. pop(self: gridpack.dynamic_simulation.EventVector) ->
+         gridpack::dynamic_simulation::Event
+
+      Remove and return the last item
+
+      1. pop(self: gridpack.dynamic_simulation.EventVector, i: int) ->
+         gridpack::dynamic_simulation::Event
+
+      Remove and return the item at index ``i``

--- a/docs/user_manual/sphinx/python/emt.rst
+++ b/docs/user_manual/sphinx/python/emt.rst
@@ -1,0 +1,27 @@
+
+EMT
+***
+
+
+Reference
+=========
+
+GridPACK EMT Application module
+
+**class gridpack.emt.EMT**
+
+   **initialize(self: gridpack.emt.EMT) -> None**
+
+   **rank(self: gridpack.emt.EMT) -> int**
+
+   **readnetworkdatafromconfig(self: gridpack.emt.EMT) -> None**
+
+   **setconfigurationfile(self: gridpack.emt.EMT, arg0: str) -> None**
+
+   **setup(self: gridpack.emt.EMT) -> None**
+
+   **size(self: gridpack.emt.EMT) -> int**
+
+   **solve(self: gridpack.emt.EMT) -> None**
+
+   **solvepowerflow(self: gridpack.emt.EMT) -> None**

--- a/docs/user_manual/sphinx/python/gridpack.rst
+++ b/docs/user_manual/sphinx/python/gridpack.rst
@@ -1,0 +1,196 @@
+
+Base
+****
+
+The base ``gridpack`` Python module contains several utility classes.
+
+
+Parallel Environment
+====================
+
+The GridPACK parallel environment is initialized by instantiating an
+instance of ``gridpack.Environment``.
+
+
+Usage
+-----
+
+A minimal example:
+
+.. code:: python
+
+   import gridpack
+
+   env = gridpack.Environment()
+   comm = gridpack.Communicator()
+
+   c = gridpack.Communicator()
+   sys.stdout.write("hello from process %d of %d\n" %
+                    (c.rank(), c.size()))
+
+
+Reference
+---------
+
+**class gridpack.Environment**
+
+   GridPACK parallel environment
+
+**class gridpack.Communicator**
+
+   GridPACK parallel communicator
+
+   **barrier(self: gridpack.Communicator) -> None**
+
+   **divide(self: gridpack.Communicator, arg0: int) ->
+   `gridpack.Communicator <#gridpack.Communicator>`_**
+
+   **rank(self: gridpack.Communicator) -> int**
+
+   **size(self: gridpack.Communicator) -> int**
+
+   **split(self: gridpack.Communicator, arg0: int) ->
+   `gridpack.Communicator <#gridpack.Communicator>`_**
+
+   **sync(self: gridpack.Communicator) -> None**
+
+   **worldRank(self: gridpack.Communicator) -> int**
+
+
+Configuration
+=============
+
+``Configuration`` is a hierarchical database for storing and
+retrieving keyword/value pairs. It is by GridPACK applications to read
+initial input files from XML format files.
+
+
+Usage
+-----
+
+A minimal example
+
+
+Reference
+---------
+
+**class gridpack.Configuration**
+
+   Configuration database
+
+   ``KeySep = '.'``
+
+   **get(self: gridpack.Configuration, arg0: str) -> object**
+
+   **getCursor(self: gridpack.Configuration, arg0: str) ->
+   gridpack.ConfigurationCursor**
+
+   **open(self: gridpack.Configuration, arg0: str, arg1:
+   gridpack.Communicator) -> bool**
+
+
+Task Manager
+============
+
+The ``TaskManager`` is used to distribute and execute an arbitrary
+numbre of tasks across available processors.
+
+
+Usage
+-----
+
+A minimal example
+
+.. code:: python
+
+   import gridpack
+
+   env = gridpack.Environment()
+   c = gridpack.Communicator()
+   tskmgr = gridpack.TaskManager(c)
+
+   task = gridpack.TaskCounter()
+
+   tskmgr.set(100)
+   while tskmgr.nextTask(task):
+       sys.stdout.write("process %d of %d executing task %d\n" %
+                        (c.rank(), c.size(), task.task_id))
+   tskmgr = None
+
+
+Reference
+---------
+
+**class gridpack.TaskCounter**
+
+   ``property task_id``
+
+**class gridpack.TaskManager**
+
+   **cancel(self: gridpack.TaskManager) -> None**
+
+   **nextTask(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. nextTask(self: gridpack.TaskManager, arg0:
+         gridpack.TaskCounter) -> bool
+
+      Get the next task from the task manager.
+
+      1. nextTask(self: gridpack.TaskManager, arg0:
+         gridpack.Communicator, arg1: gridpack.TaskCounter) -> bool
+
+      Get the next task from the task manager on a (sub)communicator.
+
+   **printStats(self: gridpack.TaskManager) -> None**
+
+      Print out statistics on how tasks are distributed on processors
+
+   **set(self: gridpack.TaskManager, arg0: int) -> None**
+
+      Specify total number of tasks and set task manager to zero
+
+
+Utility Classes
+===============
+
+
+Reference
+---------
+
+**class gridpack.CoarseTimer**
+
+   A general purpose execution timer
+
+   **configTimer(self: gridpack.CoarseTimer, arg0: bool) -> None**
+
+   **createCategory(self: gridpack.CoarseTimer, arg0: str) -> int**
+
+   **currentTime(self: gridpack.CoarseTimer) -> float**
+
+   **dump(self: gridpack.CoarseTimer) -> None**
+
+   **dumpProfile(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. dumpProfile(self: gridpack.CoarseTimer, arg0: int) -> None
+
+      2. dumpProfile(self: gridpack.CoarseTimer, arg0: str) -> None
+
+   **start(self: gridpack.CoarseTimer, arg0: int) -> None**
+
+   **stop(self: gridpack.CoarseTimer, arg0: int) -> None**
+
+**class gridpack.NoPrint**
+
+   Device to control output volume
+
+   **setStatus(self: gridpack.NoPrint, arg0: bool) -> None**
+
+      Set status
+
+   **status(self: gridpack.NoPrint) -> bool**
+
+      Get current status

--- a/docs/user_manual/sphinx/python/hadrec.rst
+++ b/docs/user_manual/sphinx/python/hadrec.rst
@@ -1,0 +1,266 @@
+
+HADREC
+******
+
+
+Reference
+=========
+
+GridPACK HADREC Application module
+
+**class gridpack.hadrec.Action**
+
+   ``property actiontype``
+
+   ``property branch_ckt``
+
+   ``property brch_from_bus_number``
+
+   ``property brch_to_bus_number``
+
+   ``property bus_number``
+
+   ``property componentID``
+
+   ``property percentage``
+
+**class gridpack.hadrec.Module**
+
+   **applyAction(self: gridpack.hadrec.Module, arg0:
+   gridpack.hadrec.Action) -> None**
+
+   **executeDynSimuOneStep(self: gridpack.hadrec.Module) -> None**
+
+   **exportPSSE23(self: gridpack.hadrec.Module, s: str = '') -> None**
+
+   **exportPSSE33(self: gridpack.hadrec.Module, s: str = '') -> None**
+
+   **exportPSSE34(self: gridpack.hadrec.Module, s: str = '') -> None**
+
+   **fullInitializationBeforeDynSimuSteps(self:
+   gridpack.hadrec.Module, s: str = '', BusFaults:
+   gridpack.dynamic_simulation.EventVector =
+   <gridpack.dynamic_simulation.EventVector object at 0x1296345e2eb0>,
+   pfcase_idx: int = -1, dscase_idx: int) -> None**
+
+   **getBranchEndpoints(self: gridpack.hadrec.Module, arg0: int) ->
+   tuple**
+
+   **getBranchInfoBool(self: gridpack.hadrec.Module, bus_idx: int,
+   name: str, dev_idx: int | None = -1) -> object**
+
+   **getBranchInfoInt(self: gridpack.hadrec.Module, bus_idx: int,
+   name: str, dev_idx: int | None = -1) -> object**
+
+   **getBranchInfoReal(self: gridpack.hadrec.Module, bus_idx: int,
+   name: str, dev_idx: int | None = -1) -> object**
+
+   **getBranchInfoString(self: gridpack.hadrec.Module, bus_idx: int,
+   name: str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoBool(self: gridpack.hadrec.Module, bus_idx: int, name:
+   str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoInt(self: gridpack.hadrec.Module, bus_idx: int, name:
+   str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoReal(self: gridpack.hadrec.Module, bus_idx: int, name:
+   str, dev_idx: int | None = -1) -> object**
+
+   **getBusInfoString(self: gridpack.hadrec.Module, bus_idx: int,
+   name: str, dev_idx: int | None = -1) -> object**
+
+   **getBusTotalLoadPower(self: gridpack.hadrec.Module, arg0: int) ->
+   object**
+
+   **getConnectedBranches(self: gridpack.hadrec.Module, arg0: int) ->
+   list[int]**
+
+   **getDataCollectionBranchParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. getDataCollectionBranchParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: int, arg2: str, arg3: str) -> object
+
+      2. getDataCollectionBranchParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: int, arg2: str, arg3: str) -> object
+
+   **getDataCollectionBusParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. getDataCollectionBusParam(self: gridpack.hadrec.Module, arg0:
+         int, arg1: str) -> object
+
+      2. getDataCollectionBusParam(self: gridpack.hadrec.Module, arg0:
+         int, arg1: str) -> object
+
+   **getDataCollectionGenParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. getDataCollectionGenParam(self: gridpack.hadrec.Module, arg0:
+         int, arg1: str, arg2: str) -> object
+
+      2. getDataCollectionGenParam(self: gridpack.hadrec.Module, arg0:
+         int, arg1: str, arg2: str) -> object
+
+   **getDataCollectionLoadParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. getDataCollectionLoadParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: str) -> object
+
+      2. getDataCollectionLoadParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: str) -> object
+
+   **getGeneratorPower(self: gridpack.hadrec.Module, arg0: int, arg1:
+   str) -> object**
+
+   **getObservationLists(self: gridpack.hadrec.Module) -> tuple**
+
+   **getObservationLists_withBusFreq(self: gridpack.hadrec.Module) ->
+   tuple**
+
+   **getObservations(self: gridpack.hadrec.Module) -> list[float]**
+
+   **getPFSolutionSingleBus(self: gridpack.hadrec.Module, arg0: int)
+   -> object**
+
+   **getState(self: gridpack.hadrec.Module, arg0: int, arg1: str,
+   arg2: str, arg3: str) -> object**
+
+   **getZoneGeneratorPower(self: gridpack.hadrec.Module) -> object**
+
+   **getZoneLoads(self: gridpack.hadrec.Module) -> object**
+
+   **initializeDynSimu(self: gridpack.hadrec.Module, faults:
+   gridpack.dynamic_simulation.EventVector =
+   <gridpack.dynamic_simulation.EventVector object at 0x1296345cc870>,
+   dscase_idx: int = -1) -> None**
+
+   **isDynSimuDone(self: gridpack.hadrec.Module) -> bool**
+
+   **modifyDataCollectionBranchParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionBranchParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: int, arg2: str, arg3: str, arg4: float) ->
+         bool
+
+      2. modifyDataCollectionBranchParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: int, arg2: str, arg3: str, arg4: int) ->
+         bool
+
+   **modifyDataCollectionBusParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionBusParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: float) -> bool
+
+      2. modifyDataCollectionBusParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: int) -> bool
+
+   **modifyDataCollectionGenParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionGenParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: str, arg3: float) -> bool
+
+      2. modifyDataCollectionGenParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: str, arg3: int) -> bool
+
+   **modifyDataCollectionLoadParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionLoadParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: str, arg3: float) -> bool
+
+      2. modifyDataCollectionLoadParam(self: gridpack.hadrec.Module,
+         arg0: int, arg1: str, arg2: str, arg3: int) -> bool
+
+   **numGenerators(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numGenerators(self: gridpack.hadrec.Module) -> int
+
+      2. numGenerators(self: gridpack.hadrec.Module, arg0: int) -> int
+
+   **numLines(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numLines(self: gridpack.hadrec.Module) -> int
+
+      2. numLines(self: gridpack.hadrec.Module, arg0: int) -> int
+
+   **numLoads(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numLoads(self: gridpack.hadrec.Module) -> int
+
+      2. numLoads(self: gridpack.hadrec.Module, arg0: int) -> int
+
+   **numStorage(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. numStorage(self: gridpack.hadrec.Module) -> int
+
+      2. numStorage(self: gridpack.hadrec.Module, arg0: int) -> int
+
+   **readPowerFlowData(self: gridpack.hadrec.Module, s: str = '',
+   pfcase_idx: int = -1) -> None**
+
+   **scatterInjectionLoad(self: gridpack.hadrec.Module, vbusNum:
+   list[int] = [], vloadP: list[float] = [], vloadQ: list[float] = [])
+   -> None**
+
+   **scatterInjectionLoadNew(self: gridpack.hadrec.Module, vbusNum:
+   list[int] = [], vloadP: list[float] = [], vloadQ: list[float] = [])
+   -> None**
+
+   **scatterInjectionLoadNewConstCur(self: gridpack.hadrec.Module,
+   vbusNum: list[int] = [], vCurR: list[float] = [], vCurI:
+   list[float] = []) -> None**
+
+   **scatterInjectionLoadNew_Norton(self: gridpack.hadrec.Module,
+   vbusNum: list[int] = [], vloadP: list[float] = [], vloadQ:
+   list[float] = [], vimpedanceR: list[float] = [], vimpedanceI:
+   list[float] = []) -> None**
+
+   **scatterInjectionLoadNew_compensateY(self: gridpack.hadrec.Module,
+   vbusNum: list[int] = [], vloadP: list[float] = [], vloadQ:
+   list[float] = []) -> None**
+
+   **setState(self: gridpack.hadrec.Module, arg0: int, arg1: str,
+   arg2: str, arg3: str, arg4: float) -> bool**
+
+   **setWideAreaControlSignal(self: gridpack.hadrec.Module,
+   bus_number: int = '-1', genid: str = '', wideAreaControlSignal:
+   float = 0.0) -> None**
+
+   **solvePowerFlow(self: gridpack.hadrec.Module) -> bool**
+
+   **solvePowerFlowBeforeDynSimu(self: gridpack.hadrec.Module, s: str
+   = '', pfcase_idx: int = -1) -> None**
+
+   **solvePowerFlowBeforeDynSimu_withFlag(self:
+   gridpack.hadrec.Module, s: str = '', pfcase_idx: int = -1) ->
+   bool**
+
+   **totalBranches(self: gridpack.hadrec.Module) -> int**
+
+   **totalBuses(self: gridpack.hadrec.Module) -> int**
+
+   **transferPFtoDS(self: gridpack.hadrec.Module) -> None**
+
+   **updateData(self: gridpack.hadrec.Module) -> None**

--- a/docs/user_manual/sphinx/python/index.rst
+++ b/docs/user_manual/sphinx/python/index.rst
@@ -1,0 +1,19 @@
+
+GridPACK Python Interface Documentation
+***************************************
+
+Contents:
+
+.. toctree::
+   :name: pythontoc
+   :maxdepth: 3
+
+   gridpack
+   
+   powerflow
+
+   dynamic_simulation
+
+   hadrec
+
+   emt

--- a/docs/user_manual/sphinx/python/powerflow.rst
+++ b/docs/user_manual/sphinx/python/powerflow.rst
@@ -1,0 +1,396 @@
+
+Power Flow
+**********
+
+The Python Power Flow interface mirrors closely the ``PFAppModule``
+C++ interface.  See the `that module's documentation
+<https://gridpack.readthedocs.io/en/latest/Section8-ApplicationModules.html#power-flow>`_
+for most details.
+
+
+Usage
+=====
+
+A minimal example:
+
+.. code:: python
+
+   import sys, os
+   import gridpack
+   import gridpack.powerflow
+
+   env = gridpack.Environment()
+   comm = gridpack.Communicator()
+   config = gridpack.Configuration()
+   config.open("input.xml", comm)
+
+   pfapp = gridpack.powerflow.Powerflow()
+   pfapp.readNetwork(config, -1)
+   pfapp.initialize()
+   pfapp.solve();
+   pfapp.write();
+
+   # try to force deletion order to avoid problems
+   del pfapp
+   del env
+
+
+Reference
+=========
+
+GridPACK power flow module
+
+**class gridpack.powerflow.Powerflow**
+
+   Power flow application module
+
+   **checkLineOverloadViolations(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. checkLineOverloadViolations(self:
+         gridpack.powerflow.Powerflow) -> bool
+
+      Check to see if there are any line overload violations in the
+      network
+
+      1. checkLineOverloadViolations(self:
+         gridpack.powerflow.Powerflow, arg0: int) -> bool
+
+      Check to see if there are any line overload violations in an
+      area
+
+      1. checkLineOverloadViolations(self:
+         gridpack.powerflow.Powerflow, arg0: list[int], arg1:
+         list[int], arg2: list[str]) -> object
+
+      Check for overload violations on specific lines
+
+      Parameters:
+            bus1 : list of int
+               original index of “from” bus for branch
+
+            bus2 : list of int
+               original index of “to” bus for branch
+
+            tags : list of int
+               line IDs for individual lines
+
+         violations true if violation detected on branch, false
+         otherwise
+
+      Returns:
+         True if no violations found, list of flags for each line
+         otherwise
+
+   **checkQlimViolations(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. checkQlimViolations(self: gridpack.powerflow.Powerflow) ->
+         bool
+
+      Check to see if there are any Q limit violations in the network
+
+      1. checkQlimViolations(self: gridpack.powerflow.Powerflow, arg0:
+         int) -> bool
+
+      Check to see if there are any Q limit violations in an area
+
+   **checkVoltageViolations(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. checkVoltageViolations(self: gridpack.powerflow.Powerflow) ->
+         bool
+
+      Check to see if there are any voltage violations in the network”
+
+      Returns:
+         True if no violations found
+
+      1. checkVoltageViolations(self: gridpack.powerflow.Powerflow,
+         arg0: int) -> bool
+
+      Check to see if there are any voltage violations in an area
+
+      Parameters:
+         area (int): area index
+
+      Returns:
+         True if no violations found
+
+   **clearQlimViolations(self: gridpack.powerflow.Powerflow) -> None**
+
+   **clearVoltageViolations(self: gridpack.powerflow.Powerflow) ->
+   None**
+
+      Clear “ignore” parameter on all buses
+
+   **close(self: gridpack.powerflow.Powerflow) -> None**
+
+      Close redirect output file
+
+   **exportPSSE23(self: gridpack.powerflow.Powerflow, arg0: str) ->
+   None**
+
+      Export final configuration to PSS/E v23 formatted file
+
+   **exportPSSE33(self: gridpack.powerflow.Powerflow, arg0: str) ->
+   None**
+
+      Export final configuration to PSS/E v33 formatted file
+
+   **exportPSSE34(self: gridpack.powerflow.Powerflow, arg0: str) ->
+   None**
+
+      Export final configuration to PSS/E v34 formatted file
+
+   **getDataCollectionBranchParamInt(self:
+   gridpack.powerflow.Powerflow, arg0: int, arg1: int, arg2: str,
+   arg3: str) -> object**
+
+      Get (integer) load parameters in data collection for specified
+      bus
+
+   **getDataCollectionBranchParamReal(self:
+   gridpack.powerflow.Powerflow, arg0: int, arg1: int, arg2: str,
+   arg3: str) -> object**
+
+      Get (real) load parameters in data collection for specified bus
+
+   **getDataCollectionBusParamInt(self: gridpack.powerflow.Powerflow,
+   arg0: int, arg1: str) -> object**
+
+      Get (integer) load parameters in data collection for specified
+      bus
+
+   **getDataCollectionBusParamReal(self: gridpack.powerflow.Powerflow,
+   arg0: int, arg1: str) -> object**
+
+      Get (real) load parameters in data collection for specified bus
+
+   **getDataCollectionGenParamInt(self: gridpack.powerflow.Powerflow,
+   arg0: int, arg1: str, arg2: str) -> object**
+
+      Get (integer) generator parameters in data collection for
+      specified bus
+
+   **getDataCollectionGenParamReal(self: gridpack.powerflow.Powerflow,
+   arg0: int, arg1: str, arg2: str) -> object**
+
+      Get (real) generator parameters in data collection for specified
+      bus
+
+   **getDataCollectionLoadParamInt(self: gridpack.powerflow.Powerflow,
+   arg0: int, arg1: str, arg2: str) -> object**
+
+      Get (integer) load parameters in data collection for specified
+      bus
+
+   **getDataCollectionLoadParamReal(self:
+   gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2: str) ->
+   object**
+
+      Get (real) load parameters in data collection for specified bus
+
+   **getGeneratorMargins(self: gridpack.powerflow.Powerflow, arg0:
+   int, arg1: int) -> object**
+
+      Get the current real power generation and the maximum and
+      minimum total power generation for all generators in a zone. If
+      zone is less than 1 then return values for all generators in the
+      area.
+
+   **getPFSolutionSingleBus(self: gridpack.powerflow.Powerflow, arg0:
+   int) -> object**
+
+      get the power flow solution for the specific bus, vmag and v
+      angle
+
+   **getTotalLoadRealPower(self: gridpack.powerflow.Powerflow, arg0:
+   int, arg1: int) -> float**
+
+   **ignoreVoltageViolations(self: gridpack.powerflow.Powerflow) ->
+   None**
+
+      Set “ignore” parameter on all buses with violations so that
+      subsequent checks are not counted as violations
+
+   **initialize(self: gridpack.powerflow.Powerflow) -> None**
+
+      Initialize the power network. ``readNetwork()`` must be  called
+      before this.
+
+   **modifyDataCollectionBranchParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionBranchParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: int, arg2:
+         str, arg3: str, arg4: float) -> bool
+
+      Modify (real) parameters in data collection for specified branch
+
+      1. modifyDataCollectionBranchParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: int, arg2:
+         str, arg3: str, arg4: int) -> bool
+
+      Modify (integer) parameters in data collection for specified
+      branch
+
+   **modifyDataCollectionBusParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionBusParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2:
+         float) -> bool
+
+      Modify (real) parameters in data collection for specified bus
+
+      1. modifyDataCollectionBusParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2:
+         int) -> bool
+
+      Modify (integer) parameters in data collection for specified bus
+
+   **modifyDataCollectionGenParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionGenParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2:
+         str, arg3: float) -> bool
+
+      Modify (real) generator parameters in data collection for
+      specified bus
+
+      1. modifyDataCollectionGenParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2:
+         str, arg3: int) -> bool
+
+      Modify (integer) generator parameters in data collection for
+      specified bus
+
+   **modifyDataCollectionLoadParam(*args, **kwargs)**
+
+      Overloaded function.
+
+      1. modifyDataCollectionLoadParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2:
+         str, arg3: float) -> bool
+
+      Modify (real) load parameters in data collection for specified
+      bus
+
+      1. modifyDataCollectionLoadParam(self:
+         gridpack.powerflow.Powerflow, arg0: int, arg1: str, arg2:
+         str, arg3: int) -> bool
+
+      Modify (integer) load parameters in data collection for
+      specified bus
+
+   **nl_solve(self: gridpack.powerflow.Powerflow) -> bool**
+
+      Solve the power flow problem using the math library non-linear
+      solver
+
+   **open(self: gridpack.powerflow.Powerflow, arg0: str) -> None**
+
+      Redirect power flow module output from standard out to a file
+
+   **print(self: gridpack.powerflow.Powerflow, arg0: str) -> None**
+
+      Print an arbitrary string to output
+
+   **readNetwork(self: gridpack.powerflow.Powerflow, arg0:
+   gridpack.Configuration, arg1: int) -> None**
+
+      Read the network specified in the configuration.
+
+      Parameters:
+         config (gridpack.Configuration): power flow problem
+         configuration usually read from an XML file idx (int): The
+         index of the power flow problem in the configuration
+
+   **reload(self: gridpack.powerflow.Powerflow) -> None**
+
+      Reload network state and parameters from data collections
+
+   **resetPower(self: gridpack.powerflow.Powerflow) -> None**
+
+      Reset power of loads and generators to original values
+
+   **resetVoltages(self: gridpack.powerflow.Powerflow) -> None**
+
+   **saveData(self: gridpack.powerflow.Powerflow) -> None**
+
+      Save results of powerflow calculation to network data collection
+      objects
+
+   **saveDataAlsotoOrg(self: gridpack.powerflow.Powerflow) -> None**
+
+      Save results of powerflow calculation to data collection objects
+      also modify the original bus mag, ang, and the original
+      generator PG QG in the datacollection
+
+   **scaleGeneratorRealPower(self: gridpack.powerflow.Powerflow, arg0:
+   float, arg1: int, arg2: int) -> None**
+
+      Scale load power.
+
+      Parameters:
+         scale (float): factor to scale real power generation area
+         (int): area index of area for scaling generation zone (int):
+         zone index of zone for scaling generation
+
+   **scaleLoadPower(self: gridpack.powerflow.Powerflow, arg0: float,
+   arg1: int, arg2: int) -> None**
+
+   **setVoltageLimits(self: gridpack.powerflow.Powerflow, arg0: float,
+   arg1: float) -> None**
+
+      “Set voltage limits on all buses”
+
+      Parameters:
+         Vmin (float): lower bound on voltages Vmax (float): upper
+         bound on voltages
+
+   **solve(self: gridpack.powerflow.Powerflow) -> bool**
+
+      Solve the power flow problem using a custom Newton-Raphson loop
+
+   **suppressOutput(self: gridpack.powerflow.Powerflow, arg0: bool) ->
+   None**
+
+      Suppress all output from power flow module
+
+   **useRateB(self: gridpack.powerflow.Powerflow, arg0: bool) ->
+   None**
+
+      Use rate B parameter for line overload violations
+
+   **write(self: gridpack.powerflow.Powerflow) -> None**
+
+      Write out results of powerflow calculation to standard output
+
+   **writeBranch(self: gridpack.powerflow.Powerflow, arg0: str) ->
+   None**
+
+      Write branch results
+
+   **writeBus(self: gridpack.powerflow.Powerflow, arg0: str) -> None**
+
+      Write bus results
+
+   **writeHeader(self: gridpack.powerflow.Powerflow, arg0: str) ->
+   None**
+
+      Write the specified header string to output
+
+   **writeRTPRDiagnostics(self: gridpack.powerflow.Powerflow, arg0:
+   int, arg1: int, arg2: int, arg3: int, arg4: int, arg5: int, arg6:
+   str) -> None**
+
+      Write real time path rating diagnostics


### PR DESCRIPTION
This folds Python interface documentations into the user manual so it will appear  on [Read the Docs](https://gridpack.readthedocs.io/en/latest/).   Generation of the Python documentation requires the `gridpack` module be available in Python.  This means generation cannot be performed by [Read the Docs](https://gridpack.readthedocs.io/en/latest/).  So, Python interface Sphinx documents must be generated in RST format and added to the user manual document tree.   

Closes #240.