### PR TITLE
Add `results_exporter.hpp` to the exported installed files

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -29,6 +29,7 @@ install(FILES
   indexed.hpp
   sanity_interface.hpp
   string_utils.hpp
+  results_exporter.hpp
   DESTINATION include/gridpack/utilities
 )
 


### PR DESCRIPTION
Fixes Docker builds